### PR TITLE
未返却一覧をクリックすると自身のプロフィール画面に遷移するよう変更

### DIFF
--- a/src/components/navigationBar.tsx
+++ b/src/components/navigationBar.tsx
@@ -1,9 +1,11 @@
 import { FC } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { useCustomUser } from '@/hooks/useCustomUser'
 
 const NavigationBar: FC = () => {
   const router = useRouter()
+  const { user } = useCustomUser()
 
   return (
     <nav className="bg-gray-400 text-white">
@@ -32,10 +34,10 @@ const NavigationBar: FC = () => {
               登録
             </a>
           </Link>
-          <Link href="#">
+          <Link href={`/users/${user?.id}`}>
             <a
               className={`rounded-md my-auto px-3 py-2 ${
-                router.pathname === '#'
+                router.asPath === `/users/${user?.id}`
                   ? 'bg-gray-600'
                   : 'text-gray-200 hover:text-white hover:bg-gray-500'
               }`}

--- a/test/components/navigationBar.test.tsx
+++ b/test/components/navigationBar.test.tsx
@@ -1,10 +1,15 @@
-import { getByText, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import NavigationBar from '@/components/navigationBar'
+import { user1 } from '../__utils__/data/user'
 
 describe('navigationBar component', () => {
   const routerMock = jest
     .spyOn(require('next/router'), 'useRouter')
     .mockReturnValue({ push: jest.fn() })
+  const loggedInUser = user1
+  jest
+    .spyOn(require('@/hooks/useCustomUser'), 'useCustomUser')
+    .mockReturnValue({ user: loggedInUser })
 
   it('ナビゲーション項目が表示される', () => {
     const { getByText } = render(<NavigationBar />)
@@ -40,5 +45,24 @@ describe('navigationBar component', () => {
     const { getByText } = render(<NavigationBar />)
 
     expect(getByText('利用者一覧')).toHaveClass('bg-gray-600')
+  })
+
+  it('pathが/users/ログインユーザーのidの場合、未返却一覧ボタンのデザインが強調される', () => {
+    routerMock.mockReturnValueOnce({
+      push: jest.fn(),
+      asPath: `/users/${loggedInUser.id}`,
+    })
+
+    const { getByText, rerender } = render(<NavigationBar />)
+
+    expect(getByText('未返却一覧')).toHaveClass('bg-gray-600')
+
+    // ログインユーザー以外のIDの場合強調されない
+    routerMock.mockReturnValueOnce({
+      push: jest.fn(),
+      asPath: `/users/${loggedInUser.id + 1}`,
+    })
+    rerender(<NavigationBar />)
+    expect(getByText('未返却一覧')).not.toHaveClass('bg-gray-600')
   })
 })


### PR DESCRIPTION
fix #80 

### やったこと
- 未返却一覧をクリックすると自身のプロフィール画面に遷移するよう変更
