### PR TITLE
jsonProtocolの指定の削除

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["jsonProtocol"]
 }
 
 datasource db {


### PR DESCRIPTION
prisma v5で指定不要になったということなので、削除したいと思います。

参考
https://www.prisma.io/docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5#jsonprotocol-out-of-preview