### PR TITLE
auth apiのApp Router化 

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,4 +1,4 @@
-import NextAuth from 'next-auth'
+import NextAuth, { NextAuthOptions } from 'next-auth'
 import AzureADB2CProvider from 'next-auth/providers/azure-ad-b2c'
 import prisma from '@/libs/prisma/client'
 
@@ -12,7 +12,7 @@ if (
   process.exit()
 }
 
-const handler = NextAuth({
+export const authOptions: NextAuthOptions = {
   providers: [
     AzureADB2CProvider({
       tenantId: process.env.AZURE_AD_B2C_TENANT_NAME,
@@ -75,6 +75,7 @@ const handler = NextAuth({
       return session
     },
   },
-})
+}
 
+const handler = NextAuth(authOptions)
 export { handler as GET, handler as POST }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,6 @@
 import NextAuth from 'next-auth'
 import AzureADB2CProvider from 'next-auth/providers/azure-ad-b2c'
-import { sdk } from '@/libs/graphql-codegen/sdk'
-import { User } from '@/models/user'
+import prisma from '@/libs/prisma/client'
 
 if (
   !process.env.AZURE_AD_B2C_TENANT_NAME ||
@@ -13,7 +12,7 @@ if (
   process.exit()
 }
 
-export default NextAuth({
+const handler = NextAuth({
   providers: [
     AzureADB2CProvider({
       tenantId: process.env.AZURE_AD_B2C_TENANT_NAME,
@@ -35,30 +34,36 @@ export default NextAuth({
       return token
     },
     async session({ session, token }) {
-      if (token.name == null || token.email == null || token.sub == null || token.idToken === undefined) {
+      if (token.name == null || token.email == null || token.idToken === undefined) {
         return session
       }
 
-      const getUser = async (sub: string, name: string, email: string, imageUrl: string | undefined | null): Promise<User | undefined> => {
-        const maybeUser = await sdk().getUserQuery({ sub })
-        if(maybeUser.users.length > 0) {
-          return maybeUser.users[0]
+      const getUser = async (name: string, email: string, imageUrl: string | undefined | null) => {
+        const maybeUser = await prisma.user.findUnique({ where: { email } })
+        if (maybeUser != null) {
+          return maybeUser
         }
 
-        const newUser = await sdk().insertUserQuery({
-          name: name,
-          email: email,
-          sub: sub,
-          imageUrl: imageUrl,
-        })
-        if (newUser.insert_users?.returning?.length ?? 0  === 0) {
+        const newUser = await prisma.user
+          .create({
+            data: {
+              name: name,
+              email: email,
+              imageUrl: imageUrl,
+            },
+          })
+          .catch((e) => {
+            console.error(e)
+            return new Error('User create failed')
+          })
+        if (newUser instanceof Error) {
           return undefined
         }
 
-        return newUser.insert_users?.returning[0]
+        return newUser
       }
 
-      const maybeUser = await getUser(token.sub, token.name, token.email, token.picture)
+      const maybeUser = await getUser(token.name, token.email, token.picture)
       if (!maybeUser) {
         return session
       }
@@ -71,3 +76,5 @@ export default NextAuth({
     },
   },
 })
+
+export { handler as GET, handler as POST }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import NavigationBar from '@/components/navigationBar'
 import { getServerSession } from 'next-auth'
-import prisma from '@/libs/prisma/client'
+import { authOptions } from '@/app/api/auth/[...nextauth]/route'
 
 import '../styles/globals.css'
 
@@ -9,13 +9,8 @@ export const metadata = {
 }
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const session = await getServerSession()
-  const email = session?.user?.email
-  const userId = email
-    ? await prisma.user.findUnique({ where: { email } }).then((user) => {
-        return user?.id
-      })
-    : undefined
+  const session = await getServerSession(authOptions)
+  const userId = session?.customUser.id
 
   return (
     <html lang="ja">

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -2,7 +2,6 @@ export type User = {
   id: number
   name: string
   email: string
-  sub: string
 }
 
 export const isUser = (value: any): value is User => {


### PR DESCRIPTION
## やったこと
- sessionからprismaで取得したユーザーIDが取得できるように、ユーザーがDBに存在するかの判定をprismaで行うようにしました
- App Routerにしました

## 備考
- App Routerにしたときに、`export default NextAuth({...})`だと、App RouterのAPIルートの書き方と合わないため、下記を参考に修正しました
  - https://qiita.com/kage1020/items/8224efd0f3557256c541#%E5%AE%9F%E8%A3%85
