### PR TITLE
ADRのDiscussionテンプレートの追加

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/architecture-decision-record.yml
+++ b/.github/DISCUSSION_TEMPLATE/architecture-decision-record.yml
@@ -1,0 +1,36 @@
+labels: [ Architecture Decision Record ]
+body:
+  - type: dropdown
+    attributes:
+      label: ステータス
+      description: この文書のステータスを選択してください。
+      options:
+        - "提案済み"
+        - "承認済み"
+        - "破棄"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: コンテキスト
+      description: この決定を行った状況について書いてください。
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 決定
+      description: 決定とその根拠について書いてください。
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 影響
+      description: 決定による影響や、比較・検討した内容について書いてください。
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 備考
+      description: 参考文献等あれば書いてください。
+    validations:
+      required: false


### PR DESCRIPTION
## 概要

DiscussionsでADRを保持していくことにしたものの、テンプレートがないためにフォーマットがバラバラになりそうだった。
@katakoto291 さんより、 テンプレートの作成のやり方を教えていただいたので、それを反映します。

## 参考

https://tech.excite.co.jp/entry/2023/07/24/100404