### PR TITLE
ヘッダーにログインユーザー情報を表示する

### DIFF
--- a/src/app/navigationBar.tsx
+++ b/src/app/navigationBar.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 const NavigationBar: FC = async () => {
   const session = await getServerSession(authOptions)
   const userId = session?.customUser.id
+  const userName = session?.customUser.name
 
   return (
     <div className="bg-gray-400 text-white">
@@ -30,6 +31,7 @@ const NavigationBar: FC = async () => {
             <li>
               <NavigationBarItem label="利用者一覧" href="/users" />
             </li>
+            <li className="pl-3 my-auto text-gray-200">{userName}</li>
           </ul>
         </div>
       </nav>

--- a/test/app/navigationBar.test.tsx
+++ b/test/app/navigationBar.test.tsx
@@ -8,7 +8,11 @@ jest.mock('next/navigation', () => ({
 }))
 
 const loggedInUser = user1
-const getServerSessionMock = jest.fn().mockReturnValue({ customUser: { id: loggedInUser.id } })
+const getServerSessionMock = jest
+  .fn()
+  .mockReturnValue({
+    customUser: { id: loggedInUser.id, name: loggedInUser.name, email: loggedInUser.email },
+  })
 jest.mock('next-auth', () => ({
   __esModule: true,
   getServerSession: () => getServerSessionMock(),
@@ -34,6 +38,7 @@ describe('navigationBar component', () => {
     expect(screen.getByRole('link', { name: 'マイページ' })).not.toHaveClass('bg-gray-600')
     expect(screen.getByRole('link', { name: '利用者一覧' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '利用者一覧' })).not.toHaveClass('bg-gray-600')
+    expect(screen.getByText(loggedInUser.name)).toBeInTheDocument()
   })
 
   it('company-libraryをクリックすると書籍一覧画面へ遷移する', async () => {


### PR DESCRIPTION
fix #147 

ユーザー名を表示します
ロゴの表示については #150 の対応が完了したのちに、対応することを想定し、 #156 を追加しました
また、 #156 をfirst releaseでリリースするかはわからないので、NoStatusのバックログに追加しました