### PR TITLE
ユーザーアバターを gravatar から取得する

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   images: {
     remotePatterns: [
       { hostname: 'books.google.com' },
-      { hostname: 's.gravatar.com' },
+      { hostname: 'gravatar.com' },
       { hostname: 'picsum.photos' },
     ],
   },

--- a/src/app/users/userCard.tsx
+++ b/src/app/users/userCard.tsx
@@ -8,7 +8,7 @@ type UserCardProps = {
   user: UserSummary
 }
 
-const UserCard: FC<UserCardProps> = ({ user }) => {
+const UserCard: FC<UserCardProps> = async ({ user }) => {
   const { readingBooks, haveReadBooks } = readingHistories(user.lendingHistories)
 
   return (

--- a/src/components/userAvatar.tsx
+++ b/src/components/userAvatar.tsx
@@ -1,21 +1,24 @@
 import Image from 'next/image'
 import { FC } from 'react'
+import { getAvatarUrl } from '@/libs/gravatar/getAvatarUrl'
 
 type UserAvatarProps = {
   user: {
     name: string
-    imageUrl?: string | null
+    email: string
   }
 }
 
-const UserAvatar: FC<UserAvatarProps> = ({ user }) => {
+const UserAvatar: FC<UserAvatarProps> = async ({ user }) => {
+  const imageUrl = await getAvatarUrl(user.email)
+
   return (
     <div className="tooltip" data-tip={user.name} data-testid="name-tooltip">
-      {user.imageUrl ? (
+      {imageUrl ? (
         <div className="avatar">
           <div className="w-12 rounded-full">
             <Image
-              src={user.imageUrl}
+              src={imageUrl}
               alt={`${user.name}のプロフィール画像`}
               width="48"
               height="48"

--- a/src/libs/gravatar/getAvatarUrl.ts
+++ b/src/libs/gravatar/getAvatarUrl.ts
@@ -1,0 +1,21 @@
+import crypto from 'crypto'
+
+export const getAvatarUrl = async (email: string) => {
+  const hash = getGravatarHash(email)
+  const requestUrl = `https://gravatar.com/avatar/${hash}.jpg`
+
+  const resp = await fetch(`${requestUrl}?d=404`).catch((e) => {
+    console.error('gravatar fetch failed', e)
+    return new Error('gravatar fetch failed')
+  })
+
+  if (resp instanceof Error || !resp.ok) {
+    return undefined
+  }
+
+  return `${requestUrl}?d=mp`
+}
+
+const getGravatarHash = (email: string) => {
+  return crypto.createHash('sha256').update(email.trim().toLowerCase()).digest('hex')
+}

--- a/test/app/books/id/impressionList.test.tsx
+++ b/test/app/books/id/impressionList.test.tsx
@@ -3,6 +3,12 @@ import { prismaMock } from '../../../__utils__/libs/prisma/singleton'
 import { lendableBook } from '../../../__utils__/data/book'
 
 describe('ImpressionList component', () => {
+  const UserAvatarMock = jest.fn().mockImplementation(({ user }) => <div>{user.name}</div>)
+  jest.mock('@/components/userAvatar', () => ({
+    __esModule: true,
+    default: (...args: any) => UserAvatarMock(...args),
+  }))
+
   const ImpressionListComponent = require('@/app/books/[id]/impressionList').default
 
   const prismaImpressionsMock = prismaMock.impression.findMany
@@ -38,15 +44,15 @@ describe('ImpressionList component', () => {
 
     expect(prismaImpressionsMock.mock.calls[0][0]?.orderBy).toStrictEqual([{ updatedAt: 'desc' }])
     expect(screen.getByTestId(`postedDate-${0}`).textContent).toBe('2022/11/01')
-    expect(screen.getByTestId(`postedUser-${0}`).textContent).toBe('u')
+    expect(screen.getByTestId(`postedUser-${0}`).textContent).toBe(expectedImpressions[0].user.name)
     expect(screen.getByTestId(`impression-${0}`).textContent).toBe('興味深い本でした')
     expect(screen.getByTestId(`postedDate-${1}`).textContent).toBe('2022/10/31')
-    expect(screen.getByTestId(`postedUser-${1}`).textContent).toBe('u')
+    expect(screen.getByTestId(`postedUser-${1}`).textContent).toBe(expectedImpressions[1].user.name)
     expect(screen.getByTestId(`impression-${1}`).textContent).toBe(
       '本の感想です。\n面白かったです。',
     )
     expect(screen.getByTestId(`postedDate-${2}`).textContent).toBe('2022/10/21')
-    expect(screen.getByTestId(`postedUser-${2}`).textContent).toBe('u')
+    expect(screen.getByTestId(`postedUser-${2}`).textContent).toBe(expectedImpressions[2].user.name)
     expect(screen.getByTestId(`impression-${2}`).textContent).toBe('感想')
   })
 

--- a/test/app/books/id/lendingList.test.tsx
+++ b/test/app/books/id/lendingList.test.tsx
@@ -4,6 +4,12 @@ import { lendableBook } from '../../../__utils__/data/book'
 import { DateTime, Settings } from 'luxon'
 
 describe('LendingList Component', () => {
+  const UserAvatarMock = jest.fn().mockImplementation(({ user }) => <div>{user.name}</div>)
+  jest.mock('@/components/userAvatar', () => ({
+    __esModule: true,
+    default: (...args: any) => UserAvatarMock(...args),
+  }))
+
   const LendingListComponent = require('@/app/books/[id]/lendingList').default
 
   const expectedLendingHistories = [
@@ -37,11 +43,17 @@ describe('LendingList Component', () => {
 
     expect(prismaLendingHistoryMock.mock.calls[0][0]?.orderBy).toStrictEqual([{ lentAt: 'asc' }])
     expect(screen.getByTestId(`dueDate-${0}`).textContent).toBe('2022/10/30')
-    expect(screen.getByTestId(`lendingUser-${0}`).textContent).toBe('u')
+    expect(screen.getByTestId(`lendingUser-${0}`).textContent).toBe(
+      expectedLendingHistories[0].user.name,
+    )
     expect(screen.getByTestId(`dueDate-${1}`).textContent).toBe('2022/10/31')
-    expect(screen.getByTestId(`lendingUser-${1}`).textContent).toBe('u')
+    expect(screen.getByTestId(`lendingUser-${1}`).textContent).toBe(
+      expectedLendingHistories[1].user.name,
+    )
     expect(screen.getByTestId(`dueDate-${2}`).textContent).toBe('2022/11/01')
-    expect(screen.getByTestId(`lendingUser-${2}`).textContent).toBe('u')
+    expect(screen.getByTestId(`lendingUser-${2}`).textContent).toBe(
+      expectedLendingHistories[2].user.name,
+    )
   })
 
   it('返却予定日は、表示した日を過ぎていた場合、赤太字になる', async () => {

--- a/test/app/books/id/returnList.test.tsx
+++ b/test/app/books/id/returnList.test.tsx
@@ -3,6 +3,12 @@ import { prismaMock } from '../../../__utils__/libs/prisma/singleton'
 import { lendableBook } from '../../../__utils__/data/book'
 
 describe('ReturnList Component', () => {
+  const UserAvatarMock = jest.fn().mockImplementation(({ user }) => <div>{user.name}</div>)
+  jest.mock('@/components/userAvatar', () => ({
+    __esModule: true,
+    default: (...args: any) => UserAvatarMock(...args),
+  }))
+
   const ReturnListComponent = require('@/app/books/[id]/returnList').default
 
   const expectedReturnHistories = [
@@ -46,11 +52,17 @@ describe('ReturnList Component', () => {
 
     expect(prismaReturnHistoryMock.mock.calls[0][0]?.orderBy).toStrictEqual([{ returnedAt: 'asc' }])
     expect(screen.getByTestId(`returnedDate-${0}`).textContent).toBe('2022/10/01〜2022/10/30')
-    expect(screen.getByTestId(`returnedUser-${0}`).textContent).toBe('u')
+    expect(screen.getByTestId(`returnedUser-${0}`).textContent).toBe(
+      expectedReturnHistories[0].lendingHistory.user.name,
+    )
     expect(screen.getByTestId(`returnedDate-${1}`).textContent).toBe('2022/10/01〜2022/10/25')
-    expect(screen.getByTestId(`returnedUser-${1}`).textContent).toBe('u')
+    expect(screen.getByTestId(`returnedUser-${1}`).textContent).toBe(
+      expectedReturnHistories[1].lendingHistory.user.name,
+    )
     expect(screen.getByTestId(`returnedDate-${2}`).textContent).toBe('2022/10/01〜2022/10/20')
-    expect(screen.getByTestId(`returnedUser-${2}`).textContent).toBe('u')
+    expect(screen.getByTestId(`returnedUser-${2}`).textContent).toBe(
+      expectedReturnHistories[2].lendingHistory.user.name,
+    )
   })
 
   it('返却履歴の取得時にエラーが発生した場合、エラーメッセージが表示される', async () => {

--- a/test/app/users/page.test.tsx
+++ b/test/app/users/page.test.tsx
@@ -5,6 +5,12 @@ import { user1, user2 } from '../../__utils__/data/user'
 describe('users page', () => {
   prismaMock.user.findMany.mockResolvedValue([user1, user2])
 
+  const UserCardMock = jest.fn().mockImplementation(({ user }) => <div>{user.name}</div>)
+  jest.mock('@/app/users/userCard', () => ({
+    __esModule: true,
+    default: (...args: any) => UserCardMock(...args),
+  }))
+
   const UserPage = require('@/app/users/page').default
 
   it('利用者一覧が表示される', async () => {

--- a/test/app/users/userCard.test.tsx
+++ b/test/app/users/userCard.test.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, render } from '@testing-library/react'
-import UserCard from '@/app/users/userCard'
-import { user1, user2 } from '../../__utils__/data/user'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { user1 } from '../../__utils__/data/user'
 
 jest.mock('next/link', () => ({
   __esModule: true,
@@ -10,22 +9,26 @@ jest.mock('next/link', () => ({
 }))
 
 describe('UserCard component', () => {
-  it('ユーザー情報が表示されていること', () => {
-    const { getByText, getByTestId } = render(<UserCard user={user1} />)
+  const UserAvatarMock = jest
+    .fn()
+    .mockImplementation(() => <div data-testid="profileImage">userAvatar</div>)
+  jest.mock('@/components/userAvatar', () => ({
+    __esModule: true,
+    default: (...args: any) => UserAvatarMock(...args),
+  }))
 
-    expect(getByText(user1.name)).toBeInTheDocument()
-    expect(getByText(user1.email)).toBeInTheDocument()
-    expect(getByTestId('profileImage')).toBeInTheDocument()
-    expect(getByTestId('userProfileLink')).toHaveAttribute('href', `/users/${user1.id}`)
-    expect(getByTestId('readingBookCount').textContent).toBe('3')
-    expect(getByTestId('haveReadBookCount').textContent).toBe('4')
+  const UserCard = require('@/app/users/userCard').default
 
-    fireEvent.click(getByText(user1.name))
-  })
+  it('ユーザー情報が表示されていること', async () => {
+    render(await UserCard({ user: user1 }))
 
-  it('ユーザー画像が存在しない場合は、ユーザー画像は表示されない', () => {
-    const { queryByTestId } = render(<UserCard user={user2} />)
+    expect(screen.getByText(user1.name)).toBeInTheDocument()
+    expect(screen.getByText(user1.email)).toBeInTheDocument()
+    expect(screen.getByTestId('profileImage')).toBeInTheDocument()
+    expect(screen.getByTestId('userProfileLink')).toHaveAttribute('href', `/users/${user1.id}`)
+    expect(screen.getByTestId('readingBookCount').textContent).toBe('3')
+    expect(screen.getByTestId('haveReadBookCount').textContent).toBe('4')
 
-    expect(queryByTestId('profileImage')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText(user1.name))
   })
 })

--- a/test/components/userAvatar.test.tsx
+++ b/test/components/userAvatar.test.tsx
@@ -1,26 +1,39 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { user1, user2 } from '../__utils__/data/user'
-import UserAvatar from '@/components/userAvatar'
 
-describe('UserCard component', () => {
-  it('ユーザー画像が表示されること', () => {
-    const { getByTestId } = render(<UserAvatar user={user1} />)
+describe('UserAvatar component', () => {
+  const getAvatarUrlMock = jest.fn()
+  jest.mock('@/libs/gravatar/getAvatarUrl', () => ({
+    __esModule: true,
+    getAvatarUrl: (email: string) => getAvatarUrlMock(email),
+  }))
 
-    expect(getByTestId('profileImage')).toBeInTheDocument()
+  const UserAvatar = require('@/components/userAvatar').default
+
+  it('ユーザー画像が表示されること', async () => {
+    getAvatarUrlMock.mockResolvedValueOnce(user1.imageUrl)
+
+    render(await UserAvatar({ user: user1 }))
+
+    expect(screen.getByTestId('profileImage')).toBeInTheDocument()
   })
 
-  it('ユーザー画像が存在しない場合は、ユーザー名先頭1文字のアイコンが表示されること', () => {
-    const { queryByTestId, getByText } = render(<UserAvatar user={user2} />)
+  it('ユーザー画像が存在しない場合は、ユーザー名先頭1文字のアイコンが表示されること', async () => {
+    getAvatarUrlMock.mockResolvedValueOnce(undefined)
 
-    expect(queryByTestId('profileImage')).not.toBeInTheDocument()
-    expect(getByText(user2.name.substring(0, 1))).toBeInTheDocument()
+    render(await UserAvatar({ user: user2 }))
+
+    expect(screen.queryByTestId('profileImage')).not.toBeInTheDocument()
+    expect(screen.getByText(user2.name.substring(0, 1))).toBeInTheDocument()
   })
 
   it('ホバーさせると、ツールチップでユーザー名が表示されること', async () => {
-    const user = user1
-    const { queryByText, getByTestId } = render(<UserAvatar user={user} />)
-    expect(queryByText(user.name)).not.toBeInTheDocument()
+    getAvatarUrlMock.mockResolvedValueOnce(user1.imageUrl)
 
-    expect(getByTestId('name-tooltip')).toHaveClass('tooltip')
+    const user = user1
+    render(await UserAvatar({ user: user1 }))
+    expect(screen.queryByText(user.name)).not.toBeInTheDocument()
+
+    expect(screen.getByTestId('name-tooltip')).toHaveClass('tooltip')
   })
 })

--- a/test/libs/gravatar/getAvatar.test.ts
+++ b/test/libs/gravatar/getAvatar.test.ts
@@ -1,0 +1,36 @@
+import { getAvatarUrl } from '@/libs/gravatar/getAvatarUrl'
+
+describe('getAvatarUrl', () => {
+  const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 })
+  global.fetch = fetchMock
+
+  it('Gravatar画像存在チェックのリクエストが成功して画像がある場合、Gravatar画像取得用のURLを返す', async () => {
+    const result = await getAvatarUrl('MyEmailAddress@example.com ')
+
+    expect(result).toBe(
+      'https://gravatar.com/avatar/84059b07d4be67b806386c0aad8070a23f18836bbaae342275dc0a83414c32ee.jpg?d=mp',
+    )
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'https://gravatar.com/avatar/84059b07d4be67b806386c0aad8070a23f18836bbaae342275dc0a83414c32ee.jpg?d=404',
+    )
+  })
+
+  it('Gravatar画像存在チェックのリクエストが成功して画像が無い場合、undefinedを返す', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await getAvatarUrl('MyEmailAddress@example.com ')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('Gravatar画像存在チェックのリクエストが失敗した場合、undefinedを返す', async () => {
+    const expectedError = new Error('network error')
+    fetchMock.mockRejectedValueOnce(expectedError)
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+    const result = await getAvatarUrl('MyEmailAddress@example.com ')
+
+    expect(result).toBeUndefined()
+    expect(consoleErrorMock).toHaveBeenLastCalledWith('gravatar fetch failed', expectedError)
+  })
+})


### PR DESCRIPTION
[Gravatarのドキュメント](https://docs.gravatar.com/)を参考に実装

gravatarから取得できなかった場合は、ユーザー名の戦先頭文字のアイコンを表示するようにしています。
![スクリーンショット 2024-01-28 13 22 44](https://github.com/company-library/company-library/assets/18738769/397a2741-34ef-458f-8b89-d93fda1c9622)
