### PR TITLE
画面によって横にずれる問題に対応

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body>
+      <body className="w-screen">
         <header>
           <NavigationBar />
         </header>


### PR DESCRIPTION
画面によってスクロールバーが表示されて、それによって画面が横にずれます
ビューポート（vw）でスクロールバーの幅込みで、幅指定を行い、画面ずれを防ぎます

fix #143 