### PR TITLE
next 系パッケージのアップデートPRがまとめられるようにする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       day: "saturday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    groups:
+      next:
+        patterns:
+          - "next"
+          - "eslint-config-next"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
 
       # 個別にグループ化したい場合はここより上に追記してください
       minor-and-patch:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
           - "next"
           - "eslint-config-next"
 
+      # 個別にグループ化したい場合はここより上に追記してください
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
#184 

## やったこと
- `groups` を設定するために `dependabot.yml` の追加
- `next` 系をまとめる設定を追加
- `prisma` 系をまとめる設定を追加
- マイナーバージョンとパッチバージョンのアップデートはまとめられるようにする

## 相談したいこと
- 確認頻度や時間について決めたい