### PR TITLE
renovate のグループ化の優先順位の修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,15 +7,6 @@
   "timezone": "Asia/Tokyo",
   "packageRules": [
     {
-      "groupName": "next",
-      "matchPackageNames": ["next", "eslint-config-next"]
-    },
-    {
-      "groupName": "prisma",
-      "matchPackageNames": ["prisma"],
-      "matchPackagePrefixes": ["@prisma"]
-    },
-    {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchPackagePatterns": [
@@ -25,6 +16,15 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "groupName": "prisma",
+      "matchPackageNames": ["prisma"],
+      "matchPackagePrefixes": ["@prisma"]
+    },
+    {
+      "groupName": "next",
+      "matchPackageNames": ["next", "eslint-config-next"]
     }
   ]
 }


### PR DESCRIPTION
## 目的
- `next` と `eslint-config-next` のグループ化よりも マイナーバージョンとパッチバージョンのグループ化が優先されてしまっているため、修正します

## やったこと
- [ドキュメント](https://docs.renovatebot.com/configuration-options/#packagerules)に以下のようにあったので、記載順を逆にしました

> packageRulesの順番は、最も重要でないルールを一番上に、最も重要なルールを一番下にします。こうすることで、必要に応じて重要なルールがそれ以前のルールの設定を上書きします。
