### PR TITLE
アーキテクチャ図にGoogle Books APIの記載を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ graph TB;
     Vercel -->|認証要求| Auth["認証<br>(Azure AD  or<br>Azure AD B2C)"];
     Vercel -->|データベースクエリ| DB["データベース<br>(Vercel Postgresql)"];
     Vercel -->|ファイルアクセス| Blob["ファイルストレージ<br>(Vercel Blob)"];
+    Vercel -->|書籍情報取得| BooksAPI["Google Books API"];
     Vercel -->|通知| Slack["Slack"];
     Auth -->|認証応答| Vercel;
     DB -->|データ応答| Vercel;
@@ -39,6 +40,7 @@ graph TB;
     style Auth fill:#f0f0f0,stroke:#000,stroke-width:3px,color:#000
     style DB fill:#f0f0f0,stroke:#000,stroke-width:3px,color:#000
     style Blob fill:#f0f0f0,stroke:#000,stroke-width:3px,color:#000
+    style BooksAPI fill:#f0f0f0,stroke:#000,stroke-width:3px,color:#000
     style Slack fill:#f0f0f0,stroke:#000,stroke-width:3px,color:#000
 ```
 


### PR DESCRIPTION
zennの記事を書いているときにGoogle Books APIの記載を忘れていることに気づいたので追記します