### PR TITLE
マイナーバージョンとパッチバージョンアップデートエラーの解消

### DIFF
--- a/test/app/books/id/lendButton.test.tsx
+++ b/test/app/books/id/lendButton.test.tsx
@@ -73,7 +73,7 @@ describe('LendButton component', () => {
     expect(lendBookMock).toBeCalledWith(
       bookId,
       userId,
-      dateStringToDate(expectedDueDate.toISODate()),
+      dateStringToDate(expectedDueDate.toISODate() ?? ''),
     )
     expect(refreshMock).toBeCalled()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8164,7 +8164,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>":
   version: 5.5.2
-  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
# 目的
#245  がエラーになっていたので、そのエラーを解消します

# やったこと
- `yarn install` の実行 1b2f6d66a37089736f2d54f0ab8cf002382224ab
- テストコードで型エラーが発生してたため修正 1372afa231e75d8c3ff193491e92a1c7fc0b79a5

# その他
- test 実行時に以下の警告が出ていますが、一旦テストは通っているのと `@testing-library/react` のアップデートが必要そうに見えたので、別途対応できればと考えています

```
Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.
```