### PR TITLE
CIを元に戻す

### DIFF
--- a/.github/workflows/reviewdogBiome.yml
+++ b/.github/workflows/reviewdogBiome.yml
@@ -1,17 +1,17 @@
 name: reviewdogBiome
-on:
-  pull_request_target:
-    types: [labeled]
+on: pull_request
 
 jobs:
   biome:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'biome check')
 
     steps:
       - uses: actions/checkout@v4
-      - uses: mongolyy/reviewdog-action-biome@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          biome_flags: 'src/ test/'
-          fail_on_error: true
+      - uses: volta-cli/action@v4
+      - run: yarn install --immutable
+      - run: yarn lint:ci
+#      - uses: mongolyy/reviewdog-action-biome@v1
+#        with:
+#          github_token: ${{ secrets.github_token }}
+#          biome_flags: 'src/ test/'
+#          fail_on_error: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "biome check src/ test/",
     "lint:fix": "biome check src/ test/ --write",
-    "lint:ci": "biome ci src/ test/",
+    "lint:ci": "biome ci src/ test/ --reporter=github",
     "test": "jest",
     "typeCheck": "tsc --pretty --noEmit",
     "db:generate": "npx prisma generate",


### PR DESCRIPTION
pull_request_targetを使うことで、reviewdogからのコメントができないか試したが、 https://github.com/actions/checkout/issues/518 の問題があり、現時点で回避できる方法がわからなかったので、ciをもとに戻します

biomeのメッセージ出力はgithub用のものとし、作業者が見やすくなるようにします