### PR TITLE
cron式が誤っていたため修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/overdue",
-      "schedule": "* * 17 ? * WED *"
+      "schedule": "* 17 * * 3"
     }
   ]
 }


### PR DESCRIPTION
cron式が誤っていたためVercelでデプロイできなくなってしまっていたので修正します

以下のサイトで有効なcron式になっているか確認しました
https://vercel.com/docs/cron-jobs#validate-cron-expressions