### PR TITLE
renovateにlockファイルの更新をさせない

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "schedule": "before 9am on Saturday",
   "timezone": "Asia/Tokyo",
   "rangeStrategy": "bump",
+  "updateLockFiles": false,
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
## 背景

renovateがlockファイルを上げるとyarn v1になって、そのあとの作業が煩雑になるので、ロックファイルの更新はrenovateを使用せず、各自のローカルで実行するようにしたい

## 修正したこと

renovateの設定を変更し、lockファイルを更新しない設定とした