### PR TITLE
cron式を修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/overdue",
-      "schedule": "* 17 * * 3"
+      "schedule": "0 17 * * 3"
     }
   ]
 }


### PR DESCRIPTION
#270 で修正しましたが、水曜の8時台に1分ごとに実行になってしまっていたため、8時00分に実行になるよう修正します

この誤りにより、1日に1回以上実行され、Hobbyプランではデプロイできなくなってしまっていました🙇‍♂️