### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildCheck.yml
+++ b/.github/workflows/buildCheck.yml
@@ -3,6 +3,9 @@ name: buildCheck
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   buildCheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdogBiome.yml
+++ b/.github/workflows/reviewdogBiome.yml
@@ -1,6 +1,9 @@
 name: reviewdogBiome
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     runs-on: ubuntu-latest

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -3,6 +3,9 @@ name: typeCheck
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   typeCheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -3,6 +3,9 @@ name: unitTest
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/company-library/company-library/security/code-scanning/59](https://github.com/company-library/company-library/security/code-scanning/59)

To fix the issue, we will add a `permissions` block at the workflow level (applies to all jobs) with the least privileges required. Since the workflow only checks out the repository and runs tests, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` used in the workflow has minimal access, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
