### PR TITLE
github actionsのバージョン指定をhashに変更

### DIFF
--- a/.github/workflows/buildCheck.yml
+++ b/.github/workflows/buildCheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
       - run: yarn install --frozen-lockfile
       - run: yarn build

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/reviewdogBiome.yml
+++ b/.github/workflows/reviewdogBiome.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
       - run: yarn install --immutable
       - run: yarn lint:ci
 #      - uses: mongolyy/reviewdog-action-biome@v1

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
       - run: yarn install --frozen-lockfile
       - run: yarn typeCheck

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
       - run: yarn install --frozen-lockfile
       - run: yarn test


### PR DESCRIPTION
## やったこと

Third partyのgithub actionsに関しては、コミットhashで固定したほうがいいとのことで対応
https://github.com/company-library/company-library/security/code-scanning/63

[pinact](https://github.com/suzuki-shunsuke/pinact)を使用して、一括で置換しました