### PR TITLE
ダークモードに対応した文字色に修正

### DIFF
--- a/src/app/users/userCard.tsx
+++ b/src/app/users/userCard.tsx
@@ -24,13 +24,13 @@ const UserCard: FC<UserCardProps> = async ({ user }) => {
         <div className="-mt-px flex divide-x divide-gray-200">
           <div className="py-3 w-0 flex-1 flex">
             <span className="ml-3 text-gray-500 text-sm">現在読んでいる冊数</span>
-            <span className="ml-1 text-sm" data-testid="readingBookCount">
+            <span className="ml-1 text-black text-sm" data-testid="readingBookCount">
               {readingBooks.length}
             </span>
           </div>
           <div className="py-3 -ml-px w-0 flex-1 flex">
             <span className="ml-3 text-gray-500 text-sm">今まで借りた冊数</span>
-            <span className="ml-1 text-sm" data-testid="haveReadBookCount">
+            <span className="ml-1 text-black text-sm" data-testid="haveReadBookCount">
               {haveReadBooks.length}
             </span>
           </div>


### PR DESCRIPTION
## やったこと
- 利用者一覧画面の冊数が、ダークモード時に背景色と同化して見えなくなってしまっていたため修正します
![スクリーンショット 2025-05-22 19 08 03](https://github.com/user-attachments/assets/50b17639-7c75-4c4c-b459-164e2a775f20)

## 確認結果
- 文字色を明示的に指定することでダークモード時でも適した色になるようにしました
![スクリーンショット 2025-05-22 19 09 10](https://github.com/user-attachments/assets/71fc0f06-e8a4-4420-876d-c435b75c2682)

修正後のライトモードも確認
![スクリーンショット 2025-05-22 19 10 02](https://github.com/user-attachments/assets/36672930-e011-4183-b0a3-1d7f59490497)



