### PR TITLE
Google Books Api で書籍が見つからなかった時にopenBDの書籍をを用いるよう変更

### DIFF
--- a/src/app/books/register/searchedBook.tsx
+++ b/src/app/books/register/searchedBook.tsx
@@ -3,7 +3,7 @@
 import AddBookDiv from '@/app/books/register/addBookDiv'
 import RegisterBookDiv from '@/app/books/register/registerBookDiv'
 import BookTile from '@/components/bookTile'
-import { GOOGLE_BOOK_SEARCH_QUERY } from '@/constants'
+import { GOOGLE_BOOK_SEARCH_QUERY, OPENBD_SEARCH_QUERY } from '@/constants'
 import fetcher from '@/libs/swr/fetcher'
 import type { Book } from '@/models/book'
 import { type CustomError, isCustomError } from '@/models/errors'
@@ -29,19 +29,67 @@ type SearchedBook = {
   ]
 }
 
+type OpenBDBooks = Array<{
+  summary: {
+    title?: string
+    cover?: string
+  }
+}>
+
 /**
  * GoogleBooksAPIから取得した書籍情報を表示するコンポーネント
  * @param {string} isbn
  * @param {number} userId
  * @returns {JSX.Element}
- * @constructor
  */
 const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
-  const { data: googleBookData } = useSWR(`${GOOGLE_BOOK_SEARCH_QUERY}${isbn}`, fetcher)
-  const googleBook: SearchedBook | undefined = googleBookData
-  const title = googleBook?.items?.[0].volumeInfo?.title
-  const thumbnailUrl = googleBook?.items?.[0].volumeInfo?.imageLinks?.thumbnail
+  const publicBook = usePublicBookData(isbn)
+  const companyBook = useCompanyBook(isbn)
 
+  if (companyBook != null) {
+    const book = { title: companyBook.title, imageUrl: companyBook.imageUrl }
+    return (
+      <>
+        <FoundBookDiv book={book} />
+        <AddBookDiv companyBook={companyBook} userId={userId} />
+      </>
+    )
+  }
+
+  if (publicBook != null) {
+    const book = { title: publicBook.title, imageUrl: publicBook.imageUrl }
+    const { title, imageUrl: thumbnailUrl } = publicBook
+    return (
+      <>
+        <FoundBookDiv book={book} />
+        <RegisterBookDiv title={title} isbn={isbn} thumbnailUrl={thumbnailUrl} userId={userId} />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <p>書籍は見つかりませんでした</p>
+    </>
+  )
+}
+
+export default SearchedBook
+
+/** 見つかった書籍を表示するコンポーネント */
+const FoundBookDiv = ({ book }: { book: { title: string; imageUrl?: string | null } }) => {
+  return (
+    <>
+      <p>こちらの本でしょうか？</p>
+      <div className="my-2 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-5">
+        <BookTile book={book} />
+      </div>
+    </>
+  )
+}
+
+/** 登録済みの書籍を取得する */
+const useCompanyBook = (isbn: string) => {
   const { data: companyBookData, error } = useSWR<
     | {
         book: Book & { _count: { registrationHistories: number } }
@@ -50,36 +98,48 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
   >(`/api/books/searchByIsbn?isbn=${isbn}`, fetcher)
   if (error || isCustomError(companyBookData)) {
     console.error(error)
-    return <div>Error!</div>
+    return null
   }
   const companyBook = companyBookData?.book
 
-  if (!title) {
-    return (
-      <>
-        <p>書籍は見つかりませんでした</p>
-      </>
-    )
+  const exists = !!companyBook?._count && companyBook._count.registrationHistories >= 1
+  if (!exists) {
+    return null
   }
 
-  const book = {
+  return companyBook
+}
+
+/** 公開されている書籍を取得する */
+const usePublicBookData = (isbn: string) => {
+  const googleBook = useGoogleBookData(isbn)
+  const openbdBook = useOpenBDData(isbn)
+
+  let title = googleBook?.items?.[0].volumeInfo?.title
+  let thumbnailUrl = googleBook?.items?.[0].volumeInfo?.imageLinks?.thumbnail
+  title ??= openbdBook?.[0]?.summary?.title
+  thumbnailUrl ??= openbdBook?.[0]?.summary?.cover
+
+  if (!title) {
+    return null
+  }
+
+  return {
     title: title,
     imageUrl: thumbnailUrl,
   }
-
-  return (
-    <>
-      <p>こちらの本でしょうか？</p>
-      <div className="my-2 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-5">
-        <BookTile book={book} />
-      </div>
-      {!!companyBook?._count && companyBook._count.registrationHistories >= 1 ? (
-        <AddBookDiv companyBook={companyBook} userId={userId} />
-      ) : (
-        <RegisterBookDiv title={title} isbn={isbn} thumbnailUrl={thumbnailUrl} userId={userId} />
-      )}
-    </>
-  )
 }
 
-export default SearchedBook
+/** GoogleBooks APIから書籍情報を取得する */
+const useGoogleBookData = (isbn: string) => {
+  const { data: googleBookData } = useSWR(`${GOOGLE_BOOK_SEARCH_QUERY}${isbn}`, fetcher)
+  const googleBook: SearchedBook | undefined = googleBookData
+  return googleBook
+}
+
+/** OpenBD APIから書籍情報を取得する */
+const useOpenBDData = (isbn: string) => {
+  const { data: openbdBookData } = useSWR(`${OPENBD_SEARCH_QUERY}${isbn}`, fetcher)
+  const openbdBook: OpenBDBooks | undefined = openbdBookData
+  return openbdBook
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const GOOGLE_BOOK_SEARCH_QUERY = 'https://www.googleapis.com/books/v1/volumes?q=isbn:'
+export const OPENBD_SEARCH_QUERY = 'https://api.openbd.jp/v1/get?isbn='
 export const DATE_DISPLAY_FORMAT = 'yyyy/MM/dd'
 export const DATE_SYSTEM_FORMAT = 'yyyy-MM-dd'


### PR DESCRIPTION
Fix #309 

Googleの方で見つからなかった時だけでなく、常にopenBDからも取得して、Googleの方でなかったらopenBDのものを使うようにしてみました