### PR TITLE
感想が横幅一杯になるように感想リストのデザイン修正

### DIFF
--- a/src/app/books/[id]/editImpressionButton.tsx
+++ b/src/app/books/[id]/editImpressionButton.tsx
@@ -48,7 +48,7 @@ const EditImpressionButton: FC<Props> = ({ impression }) => {
   return (
     <>
       <button type="button" className="btn" onClick={openModal}>
-        感想を編集
+        編集
       </button>
 
       <dialog className="modal" ref={dialogRef}>
@@ -58,8 +58,8 @@ const EditImpressionButton: FC<Props> = ({ impression }) => {
           <div className="mt-4">
             <textarea
               className="
-               textarea textarea-bordered textarea-md
-               w-full
+                textarea textarea-bordered textarea-md
+                w-full
               "
               placeholder="感想を書いてください"
               value={impressionText}

--- a/src/app/books/[id]/impressionList.tsx
+++ b/src/app/books/[id]/impressionList.tsx
@@ -34,7 +34,7 @@ const ImpressionList = async ({ bookId, userId }: Props) => {
         {recentImpressions.map((impression, index) => {
           return (
             <tr className="hover" key={impression.id}>
-              <td className="w-[15rem]" data-testid={`postedDate-${index}`}>
+              <td className="w-60" data-testid={`postedDate-${index}`}>
                 <p>{toJstFormat(impression.createdAt, DATE_TIME_DISPLAY_FORMAT)}</p>
                 {impression.createdAt.getTime() !== impression.updatedAt.getTime() && (
                   <p className="text-xs text-gray-500">
@@ -42,13 +42,13 @@ const ImpressionList = async ({ bookId, userId }: Props) => {
                   </p>
                 )}
               </td>
-              <td className="w-[5rem]" data-testid={`postedUser-${index}`}>
+              <td className="w-20" data-testid={`postedUser-${index}`}>
                 <UserAvatar user={impression.user} />
               </td>
               <td className="whitespace-pre-wrap" data-testid={`impression-${index}`}>
                 {impression.impression}
               </td>
-              <td data-testid={`edit-${index}`}>
+              <td className="w-24" data-testid={`edit-${index}`}>
                 {impression.user.id === userId && <EditImpressionButton impression={impression} />}
               </td>
             </tr>

--- a/test/app/books/id/editImpressionButton.test.tsx
+++ b/test/app/books/id/editImpressionButton.test.tsx
@@ -34,7 +34,7 @@ describe('editImpressionButton component', () => {
 
   it('ボタンをクリックすると、ダイアログが表示される', () => {
     render(<EditImpressionButton impression={impression} />)
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
 
     expect(screen.getByRole('heading', { level: 3, name: '感想を編集' })).toBeInTheDocument()
     expect(screen.getByPlaceholderText('感想を書いてください')).toHaveValue(impression.impression)
@@ -44,7 +44,7 @@ describe('editImpressionButton component', () => {
 
   it('ダイアログで感想を編集することができる', async () => {
     render(<EditImpressionButton impression={impression} />)
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
     fireEvent.change(screen.getByPlaceholderText('感想を書いてください'), {
       target: { value: '感想を編集したよ' },
     })
@@ -54,7 +54,7 @@ describe('editImpressionButton component', () => {
 
   it('ダイアログのOkボタンをクリックすると、編集処理が実行され、リロードされる', async () => {
     render(<EditImpressionButton impression={impression} />)
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
     fireEvent.change(screen.getByPlaceholderText('感想を書いてください'), {
       target: { value: '感想を編集したよ' },
     })
@@ -77,7 +77,7 @@ describe('editImpressionButton component', () => {
     window.alert = vi.fn()
 
     render(<EditImpressionButton impression={impression} />)
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
     fireEvent.change(screen.getByPlaceholderText('感想を書いてください'), {
       target: { value: '感想を編集したよ' },
     })
@@ -91,7 +91,7 @@ describe('editImpressionButton component', () => {
 
   it('ダイアログのCancelボタンをクリックすると、返却処理は実行されない', async () => {
     render(<EditImpressionButton impression={impression} />)
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
     expect(screen.getByPlaceholderText('感想を書いてください')).toHaveValue(impression.impression)
     fireEvent.change(screen.getByPlaceholderText('感想を書いてください'), {
       target: { value: '感想を編集したよ' },
@@ -105,7 +105,7 @@ describe('editImpressionButton component', () => {
       ).not.toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: '感想を編集' }))
+    fireEvent.click(screen.getByRole('button', { name: '編集' }))
     expect(screen.getByPlaceholderText('感想を書いてください')).toHaveValue(impression.impression)
   })
 })


### PR DESCRIPTION
## 目的

感想の長さによって、編集ボタンの表示位置が変わったり、表示が崩れたりしたので修正します
<img width="1024" height="221" alt="スクリーンショット 2025-07-12 23 34 23" src="https://github.com/user-attachments/assets/3d588428-e964-447b-8fa4-4ac0d2f33a33" />
<img width="995" height="201" alt="スクリーンショット 2025-07-12 23 34 50" src="https://github.com/user-attachments/assets/e0503078-4c6d-4207-ac74-76616cf7e311" />

## 確認
<img width="1000" height="201" alt="スクリーンショット 2025-07-12 23 36 36" src="https://github.com/user-attachments/assets/d5449d51-173b-4500-bc66-5b99510b5808" />
<img width="984" height="211" alt="スクリーンショット 2025-07-12 23 36 19" src="https://github.com/user-attachments/assets/53e25d91-4668-4308-be09-43454503a2a8" />


