### PR TITLE
保管場所で絞り込めるようにする

### DIFF
--- a/src/app/api/books/search/route.test.ts
+++ b/src/app/api/books/search/route.test.ts
@@ -37,7 +37,67 @@ describe('books search api', () => {
     await GET(reqWithSearchWord)
 
     expect(prismaMock.book.findMany).toBeCalledWith({
-      where: { title: { contains: searchWord, mode: 'insensitive' } },
+      where: {
+        title: { contains: searchWord, mode: 'insensitive' },
+        registrationHistories: {
+          some: {
+            location: {
+              id: undefined,
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+  })
+
+  it('保管場所IDで絞り込みを行う', async () => {
+    const locationId = '1'
+    const reqWithLocationId = new NextRequest(
+      `http://localhost:3000/api/books/search?locationId=${locationId}`,
+    )
+
+    prismaMock.book.findMany.mockResolvedValueOnce(expectedBooks)
+
+    await GET(reqWithLocationId)
+
+    expect(prismaMock.book.findMany).toBeCalledWith({
+      where: {
+        title: { contains: '', mode: 'insensitive' },
+        registrationHistories: {
+          some: {
+            location: {
+              id: 1,
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+  })
+
+  it('検索キーワードと保管場所IDの両方で絞り込みを行う', async () => {
+    const searchWord = 'testBook'
+    const locationId = '2'
+    const reqWithBothParams = new NextRequest(
+      `http://localhost:3000/api/books/search?q=${searchWord}&locationId=${locationId}`,
+    )
+
+    prismaMock.book.findMany.mockResolvedValueOnce(expectedBooks)
+
+    await GET(reqWithBothParams)
+
+    expect(prismaMock.book.findMany).toBeCalledWith({
+      where: {
+        title: { contains: searchWord, mode: 'insensitive' },
+        registrationHistories: {
+          some: {
+            location: {
+              id: 2,
+            },
+          },
+        },
+      },
       orderBy: { createdAt: 'desc' },
     })
   })
@@ -48,7 +108,16 @@ describe('books search api', () => {
     await GET(req)
 
     expect(prismaMock.book.findMany).toBeCalledWith({
-      where: { title: { contains: '', mode: 'insensitive' } },
+      where: {
+        title: { contains: '', mode: 'insensitive' },
+        registrationHistories: {
+          some: {
+            location: {
+              id: undefined,
+            },
+          },
+        },
+      },
       orderBy: { createdAt: 'desc' },
     })
   })

--- a/src/app/api/books/search/route.test.ts
+++ b/src/app/api/books/search/route.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/books/search/route'
 import type { Book } from '@/models/book'
 import { bookWithImage, bookWithoutImage } from '../../../../../test/__utils__/data/book'
@@ -6,9 +7,7 @@ import { prismaMock } from '../../../../../test/__utils__/libs/prisma/singleton'
 describe('books search api', () => {
   const expectedBooks = [bookWithImage, bookWithoutImage]
 
-  const req = {
-    url: 'http://localhost:3000/api/books/search',
-  } as Request
+  const req = new NextRequest('http://localhost:3000/api/books/search')
 
   it('本の一覧を取得し、それを返す', async () => {
     prismaMock.book.findMany.mockResolvedValueOnce(expectedBooks)
@@ -29,9 +28,9 @@ describe('books search api', () => {
 
   it('検索キーワードを用いて絞り込みを行う', async () => {
     const searchWord = 'testBook'
-    const reqWithSearchWord = {
-      url: `http://localhost:3000/api/books/search?q=${searchWord}`,
-    } as Request
+    const reqWithSearchWord = new NextRequest(
+      `http://localhost:3000/api/books/search?q=${searchWord}`,
+    )
 
     prismaMock.book.findMany.mockResolvedValueOnce(expectedBooks)
 

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -4,6 +4,7 @@ import type { CustomError } from '@/models/errors'
 
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get('q') ?? ''
+  const locationId = req.nextUrl.searchParams.get('locationId') ?? ''
 
   const books = await prisma.book
     .findMany({
@@ -11,6 +12,13 @@ export async function GET(req: NextRequest) {
         title: {
           contains: q,
           mode: 'insensitive',
+        },
+        registrationHistories: {
+          some: {
+            location: {
+              id: locationId ? Number(locationId) : undefined,
+            },
+          },
         },
       },
       orderBy: {

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -3,8 +3,9 @@ import prisma from '@/libs/prisma/client'
 import type { CustomError } from '@/models/errors'
 
 export async function GET(req: NextRequest) {
-  const q = req.nextUrl.searchParams.get('q') ?? ''
-  const locationId = req.nextUrl.searchParams.get('locationId') ?? ''
+  const searchParams = req.nextUrl.searchParams
+  const q = searchParams.get('q') ?? ''
+  const locationId = searchParams.get('locationId') ?? ''
 
   const books = await prisma.book
     .findMany({

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -1,10 +1,9 @@
-import { NextResponse } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 import prisma from '@/libs/prisma/client'
 import type { CustomError } from '@/models/errors'
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url)
-  const q = searchParams.get('q') ?? ''
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get('q') ?? ''
 
   const books = await prisma.book
     .findMany({

--- a/src/app/bookList.test.tsx
+++ b/src/app/bookList.test.tsx
@@ -4,14 +4,21 @@ import type { Mock } from 'vitest'
 import BookList from '@/app/bookList'
 import fetcher from '@/libs/swr/fetcher'
 import { bookWithImage, bookWithoutImage } from '../../test/__utils__/data/book'
+import { location1, location2 } from '../../test/__utils__/data/location'
 
-describe('BookList page', async () => {
-  vi.mock('swr')
-  const swrMock = useSWR as Mock
-  swrMock.mockReturnValue({
-    data: {
-      books: [bookWithImage, bookWithoutImage],
-    },
+vi.mock('swr')
+const swrMock = useSWR as Mock
+
+describe('BookList page', () => {
+  beforeEach(() => {
+    swrMock.mockClear()
+    // Default mock for books search and locations
+    swrMock.mockImplementation((url) => {
+      if (url === '/api/locations') {
+        return { data: { locations: [location1, location2] } }
+      }
+      return { data: { books: [bookWithImage, bookWithoutImage] } }
+    })
   })
 
   it.todo('ページタイトルが「トップページ | company-library」である')
@@ -31,26 +38,97 @@ describe('BookList page', async () => {
       target: { value: searchWord },
     })
 
-    expect(swrMock).toBeCalledWith(`/api/books/search?q=${searchWord}`, fetcher)
+    expect(swrMock).toBeCalledWith(`/api/books/search?q=${searchWord}&locationId=`, fetcher)
   })
 
   it('本の一覧の読み込み中は「Loading...」と表示される', () => {
-    swrMock.mockReturnValueOnce({ data: undefined })
+    swrMock.mockImplementation((url) => {
+      if (url === '/api/locations') {
+        return { data: { locations: [location1, location2] } }
+      }
+      return { data: undefined }
+    })
 
     render(<BookList />)
 
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
+  it('保管場所の選択肢が表示される', () => {
+    render(<BookList />)
+
+    expect(screen.getByText('全ての保管場所')).toBeInTheDocument()
+    expect(screen.getByText(location1.name)).toBeInTheDocument()
+    expect(screen.getByText(location2.name)).toBeInTheDocument()
+  })
+
+  it('保管場所を選択すると、選択した場所で絞り込み検索される', () => {
+    render(<BookList />)
+    const locationSelect = screen.getByRole('combobox')
+
+    fireEvent.change(locationSelect, { target: { value: location1.id.toString() } })
+
+    expect(swrMock).toBeCalledWith(`/api/books/search?q=&locationId=${location1.id}`, fetcher)
+  })
+
+  it('保管場所と検索キーワードの両方を指定して検索される', () => {
+    const searchWord = 'testBook'
+
+    render(<BookList />)
+
+    // Select location
+    const locationSelect = screen.getByRole('combobox')
+    fireEvent.change(locationSelect, { target: { value: location1.id.toString() } })
+
+    // Enter search keyword
+    fireEvent.change(screen.getByPlaceholderText('書籍のタイトルで検索'), {
+      target: { value: searchWord },
+    })
+
+    expect(swrMock).toBeCalledWith(
+      `/api/books/search?q=${searchWord}&locationId=${location1.id}`,
+      fetcher,
+    )
+  })
+
+  it('保管場所データの取得に失敗した場合でも、空の配列として扱われる', () => {
+    // Mock locations data with error
+    swrMock.mockImplementation((url) => {
+      if (url === '/api/locations') {
+        return { data: { errorCode: '500', message: 'Failed to fetch locations' } }
+      }
+      return { data: { books: [bookWithImage, bookWithoutImage] } }
+    })
+
+    render(<BookList />)
+
+    expect(screen.getByText('全ての保管場所')).toBeInTheDocument()
+    // Only default option should be present
+    expect(screen.queryByText(location1.name)).not.toBeInTheDocument()
+  })
+
   it('本の一覧の読み込みに失敗した場合、「Error!」と表示される', () => {
     const expectErrorMsg = 'query has errored!'
     console.error = vi.fn()
-    swrMock.mockReturnValueOnce({ data: {}, error: expectErrorMsg })
+
+    swrMock.mockImplementation((url) => {
+      if (url === '/api/locations') {
+        return { data: { locations: [location1, location2] } }
+      }
+      return { data: {}, error: expectErrorMsg }
+    })
+
     const { rerender } = render(<BookList />)
     expect(screen.getByText('Error!')).toBeInTheDocument()
     expect(console.error).toBeCalledWith(expectErrorMsg)
 
-    swrMock.mockReturnValueOnce({ data: { errorCode: '123', message: expectErrorMsg } })
+    swrMock.mockImplementation((url) => {
+      if (url === '/api/locations') {
+        return { data: { locations: [location1, location2] } }
+      }
+      return { data: { errorCode: '123', message: expectErrorMsg } }
+    })
+
     rerender(<BookList />)
     expect(screen.getByText('Error!')).toBeInTheDocument()
     // errorがfalsyの場合は、console.errorが呼び出されない

--- a/src/app/bookList.tsx
+++ b/src/app/bookList.tsx
@@ -7,10 +7,22 @@ import fetcher from '@/libs/swr/fetcher'
 import type { Book } from '@/models/book'
 import { type CustomError, isCustomError } from '@/models/errors'
 
+type Location = {
+  id: number
+  name: string
+}
+
 const BookList = () => {
+  const [searchLocation, setSearchLocation] = useState('')
+  const { data: locationsData } = useSWR<{ locations: Location[] } | CustomError>(
+    '/api/locations',
+    fetcher,
+  )
+  const locations = isCustomError(locationsData) ? [] : locationsData?.locations || []
+
   const [searchKeyword, setSearchKeyword] = useState('')
   const { data, error } = useSWR<{ books: Book[] } | CustomError>(
-    `/api/books/search?q=${searchKeyword}`,
+    `/api/books/search?q=${searchKeyword}&locationId=${searchLocation}`,
     fetcher,
   )
   if (error) {
@@ -20,11 +32,22 @@ const BookList = () => {
   return (
     <>
       <div>
-        <form>
-          <div className="relative">
+        <form className="flex gap-4">
+          <div>
+            <select className="select" onChange={(e) => setSearchLocation(e.target.value)}>
+              <option value="">全ての保管場所</option>
+              {locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex-1">
             <input
               type="search"
-              className="block p-4 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:border-blue-500"
+              className="input w-full"
               placeholder="書籍のタイトルで検索"
               onChange={(event) => setSearchKeyword(event.target.value)}
             />

--- a/src/app/bookList.tsx
+++ b/src/app/bookList.tsx
@@ -6,20 +6,16 @@ import BookTile from '@/components/bookTile'
 import fetcher from '@/libs/swr/fetcher'
 import type { Book } from '@/models/book'
 import { type CustomError, isCustomError } from '@/models/errors'
-
-type Location = {
-  id: number
-  name: string
-}
+import type { Location } from '@/models/location'
 
 const BookList = () => {
-  const [searchLocation, setSearchLocation] = useState('')
   const { data: locationsData } = useSWR<{ locations: Location[] } | CustomError>(
     '/api/locations',
     fetcher,
   )
   const locations = isCustomError(locationsData) ? [] : locationsData?.locations || []
 
+  const [searchLocation, setSearchLocation] = useState('')
   const [searchKeyword, setSearchKeyword] = useState('')
   const { data, error } = useSWR<{ books: Book[] } | CustomError>(
     `/api/books/search?q=${searchKeyword}&locationId=${searchLocation}`,

--- a/src/app/books/register/addBookDiv.tsx
+++ b/src/app/books/register/addBookDiv.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr'
 import { addBook } from '@/app/books/register/actions'
 import fetcher from '@/libs/swr/fetcher'
 import { type CustomError, isCustomError } from '@/models/errors'
+import type { Location } from '@/models/location'
 
 type AddBookDivProps = {
   companyBook: {
@@ -15,11 +16,6 @@ type AddBookDivProps = {
     }
   }
   userId: number
-}
-
-type Location = {
-  id: number
-  name: string
 }
 
 /**

--- a/src/app/books/register/registerBookDiv.tsx
+++ b/src/app/books/register/registerBookDiv.tsx
@@ -5,17 +5,13 @@ import useSWR from 'swr'
 import { registerBook } from '@/app/books/register/actions'
 import fetcher from '@/libs/swr/fetcher'
 import { type CustomError, isCustomError } from '@/models/errors'
+import type { Location } from '@/models/location'
 
 type RegisterBookDivProps = {
   title: string
   isbn: string
   thumbnailUrl: string | undefined
   userId: number
-}
-
-type Location = {
-  id: number
-  name: string
 }
 
 /**

--- a/src/models/location.ts
+++ b/src/models/location.ts
@@ -1,0 +1,4 @@
+export type Location = {
+  id: number
+  name: string
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
TOPページでの書籍の絞り込み項目に保管場所を追加します

## 動作確認項目
- 「全ての保管場所」を選択したときに、全ての保管場所の書籍が表示されること
- 保管場所を選択したときに、選択した保管場所の書籍が表示されること
- 書籍のタイトルでも絞り込めること

## レビュー希望日
- 8/3

## 関連するIssue
fix #401

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rules-->

<!-- I want to review in Japanese. -->
