### PR TITLE
借りる/返却ボタンの二重押し防止対応

### DIFF
--- a/src/app/books/[id]/actions.ts
+++ b/src/app/books/[id]/actions.ts
@@ -65,6 +65,43 @@ export const lendBookAction = async (
   }
 }
 
+type ReturnBookState = {
+  success: boolean
+  error: string | null
+}
+
+/**
+ * useActionState用の書籍返却アクション
+ */
+export const returnBookAction = async (
+  _prevState: ReturnBookState,
+  formData: FormData,
+): Promise<ReturnBookState> => {
+  const bookId = Number(formData.get('bookId'))
+  const userId = Number(formData.get('userId'))
+  const lendingHistoryId = Number(formData.get('lendingHistoryId'))
+  const impression = (formData.get('impression') as string) || ''
+
+  const result = await returnBook({
+    bookId,
+    userId,
+    lendingHistoryId,
+    impression,
+  })
+
+  if (result instanceof Error) {
+    return {
+      success: false,
+      error: result.message,
+    }
+  }
+
+  return {
+    success: true,
+    error: null,
+  }
+}
+
 /**
  * 書籍を返却するServer Action
  * @param {number} bookId 返却対象の書籍ID

--- a/src/app/books/[id]/actions.ts
+++ b/src/app/books/[id]/actions.ts
@@ -33,6 +33,38 @@ export const lendBook = async (
   return undefined
 }
 
+type LendBookState = {
+  success: boolean
+  error: string | null
+}
+
+/**
+ * useActionState用の書籍貸出アクション
+ */
+export const lendBookAction = async (
+  _prevState: LendBookState,
+  formData: FormData,
+): Promise<LendBookState> => {
+  const bookId = Number(formData.get('bookId'))
+  const userId = Number(formData.get('userId'))
+  const dueDate = new Date(formData.get('dueDate') as string)
+  const locationId = Number(formData.get('locationId'))
+
+  const result = await lendBook(bookId, userId, dueDate, locationId)
+
+  if (result instanceof Error) {
+    return {
+      success: false,
+      error: result.message,
+    }
+  }
+
+  return {
+    success: true,
+    error: null,
+  }
+}
+
 /**
  * 書籍を返却するServer Action
  * @param {number} bookId 返却対象の書籍ID


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
- 二重にボタンを押下した時に、処理も二重で実行されてしまい不整合な状態になってしまうため、できないようにします

## 動作確認項目
- [x] 借りる処理実行時に、Okボタンを押すと、ボタンが無効化され二重に押せないことを確認
- [x] 返却処理実行時に、Okボタンを押すと、ボタンが無効化され二重に押せないことを確認

## レビュー希望日
- なし

## 関連するIssue
- 未作成

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rules-->

<!-- I want to review in Japanese. -->
