### PR TITLE
next.js 15.5 用に next.config.js を更新

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,9 +10,7 @@ const nextConfig = {
       { hostname: '*.public.blob.vercel-storage.com' },
     ],
   },
-  experimental: {
-    typedRoutes: true,
-  },
+  typedRoutes: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
- Next.js 15.5 で [`typedRoutes` が安定版](https://nextjs.org/blog/next-15-5#typed-routes-stable)になり `build` 時に 以下の警告が出ていたため対応したいです

```
 ⚠ `experimental.typedRoutes` has been moved to `typedRoutes`. Please update your next.config.mjs file accordingly.
```

## 動作確認項目
- [x] `yarn build` 実行時に上記の警告が出ないこと

## レビュー希望日
- なし

## 関連するIssue
- なし

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rules-->

<!-- I want to review in Japanese. -->
