### PR TITLE
Prisma Client の generator を新しいものに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yarn-error.log*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Prisma
+**/generated/prisma

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "includes": ["**", "!**/.next", "!**/node_modules"]
+    "includes": ["**", "!**/.next", "!**/node_modules", "!**/generated/prisma"]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "../src/generated/prisma"
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
   output   = "../src/generated/prisma"
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '@/generated/prisma'
 
 const prisma = new PrismaClient()
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@/generated/prisma'
+import { PrismaClient } from '@/generated/prisma/client'
 
 const prisma = new PrismaClient()
 

--- a/src/libs/prisma/client.ts
+++ b/src/libs/prisma/client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '@/generated/prisma'
 
 let prisma: PrismaClient
 

--- a/src/libs/prisma/client.ts
+++ b/src/libs/prisma/client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@/generated/prisma'
+import { PrismaClient } from '@/generated/prisma/client'
 
 let prisma: PrismaClient
 

--- a/src/models/book.ts
+++ b/src/models/book.ts
@@ -1,3 +1,3 @@
-import type { Book as PrismaBook } from '@/generated/prisma'
+import type { BookModel as PrismaBook } from '@/generated/prisma/models'
 
 export type Book = PrismaBook

--- a/src/models/book.ts
+++ b/src/models/book.ts
@@ -1,3 +1,3 @@
-import type { Book as PrismaBook } from '@prisma/client'
+import type { Book as PrismaBook } from '@/generated/prisma'
 
 export type Book = PrismaBook

--- a/src/models/lendingHistory.ts
+++ b/src/models/lendingHistory.ts
@@ -1,3 +1,3 @@
-import type { LendingHistory as PrismaLendingHistory } from '@/generated/prisma'
+import type { LendingHistoryModel as PrismaLendingHistory } from '@/generated/prisma/models'
 
 export type LendingHistory = PrismaLendingHistory

--- a/src/models/lendingHistory.ts
+++ b/src/models/lendingHistory.ts
@@ -1,3 +1,3 @@
-import type { LendingHistory as PrismaLendingHistory } from '@prisma/client'
+import type { LendingHistory as PrismaLendingHistory } from '@/generated/prisma'
 
 export type LendingHistory = PrismaLendingHistory

--- a/src/models/returnHistory.ts
+++ b/src/models/returnHistory.ts
@@ -1,3 +1,3 @@
-import type { ReturnHistory as PrismaReturnHistory } from '@/generated/prisma'
+import type { ReturnHistoryModel as PrismaReturnHistory } from '@/generated/prisma/models'
 
 export type ReturnHistory = PrismaReturnHistory

--- a/src/models/returnHistory.ts
+++ b/src/models/returnHistory.ts
@@ -1,3 +1,3 @@
-import type { ReturnHistory as PrismaReturnHistory } from '@prisma/client'
+import type { ReturnHistory as PrismaReturnHistory } from '@/generated/prisma'
 
 export type ReturnHistory = PrismaReturnHistory

--- a/test/__utils__/libs/prisma/singleton.ts
+++ b/test/__utils__/libs/prisma/singleton.ts
@@ -1,5 +1,5 @@
-import type { PrismaClient } from '@/generated/prisma'
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended'
+import type { PrismaClient } from '@/generated/prisma/client'
 
 import prisma from '@/libs/prisma/client'
 

--- a/test/__utils__/libs/prisma/singleton.ts
+++ b/test/__utils__/libs/prisma/singleton.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from '@prisma/client'
+import type { PrismaClient } from '@/generated/prisma'
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended'
 
 import prisma from '@/libs/prisma/client'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
- Prisma Client の generator が Prisma v7 から ESM対応にしたものになる予定であるため #443 と同様に先行して対応できたらと思います

### 参考
- https://www.prisma.io/blog/why-prisma-orm-generates-code-into-node-modules-and-why-it-ll-change
- https://www.prisma.io/docs/orm/prisma-schema/overview/generators#prisma-client-preview


## 動作確認項目
- [x] `yarn db:generate` が正常終了すること
- [x] `yarn typeCheck` が正常終了すること
- [x] ローカル実行して、書籍の登録、貸出、返却ができること

## レビュー希望日
- とくになし

## 関連するIssue
- #421 

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rules-->

<!-- I want to review in Japanese. -->
