### PR TITLE
codeql-action も Commit Hash で固定する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
- Enforce SHA Pinning を有効化したことで GitHub Actions が実行されなくなっていたため修正します
  - バージョンは現時点の最新にしました
    - https://github.com/github/codeql-action/releases

## 動作確認項目
- GitHub Actions が実行されたことを確認

## レビュー希望日
- 特になし

## 関連するIssue
- なし

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rules-->

<!-- I want to review in Japanese. -->
