### PR TITLE
Migrate to Prisma Adapter for PostgreSQL

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'prisma/config'
 
 export default defineConfig({
+  datasource: {
+    url: process.env.POSTGRES_URL_NON_POOLING,
+  },
   migrations: {
     seed: 'tsx prisma/seed.ts',
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,9 +5,7 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("POSTGRES_PRISMA_URL") // uses connection pooling
-  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
+  provider = "postgresql"
 }
 
 model User {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,8 @@
+import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '@/generated/prisma/client'
 
-const prisma = new PrismaClient()
+const adapter = new PrismaPg({ connectionString: `${process.env.POSTGRES_URL_NON_POOLING}` })
+const prisma = new PrismaClient({ adapter })
 
 async function main() {
   await prisma.$executeRawUnsafe(`TRUNCATE TABLE "return_histories" RESTART IDENTITY CASCADE;`)


### PR DESCRIPTION
## 内容

Prisma の PostgreSQL アダプターを使用するように移行しました。

### 変更内容
- **prisma/schema.prisma**: データソース設定から `url` と `directUrl` を削除し、アダプター経由での接続に統一
- **prisma/seed.ts**: `PrismaPg` アダプターを導入し、`POSTGRES_URL_NON_POOLING` を使用した直接接続を設定
- **prisma.config.ts**: Prisma 設定に `datasource.url` を追加し、マイグレーション時の接続文字列を明示的に指定

この変更により、接続プーリングと直接接続の管理がアダプターレイヤーで一元化されます。

## 動作確認項目

- [ ] `prisma migrate dev` でマイグレーションが正常に実行される
- [ ] `npm run seed` でシードスクリプトが正常に実行される
- [ ] アプリケーション起動時にデータベース接続が確立される

## レビュー希望日

特に指定なし

## 関連するIssue

なし

https://claude.ai/code/session_01HY8TNhxNQKLCF2fQh8mwBQ