### PR TITLE
Pin @hono/node-server to version 1.19.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "vitest": "^4.1.5",
     "vitest-mock-extended": "^4.0.0"
   },
+  "resolutions": {
+    "@hono/node-server": "1.19.14"
+  },
   "volta": {
     "node": "24.15.0",
     "yarn": "4.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,11 +546,11 @@ __metadata:
   linkType: hard
 
 "@hono/node-server@npm:1.19.11":
-  version: 1.19.11
-  resolution: "@hono/node-server@npm:1.19.11"
+  version: 1.19.14
+  resolution: "@hono/node-server@npm:1.19.14"
   peerDependencies:
     hono: ^4
-  checksum: 10c0/34b1c29c249c5cd95469980b5c359370f3cbab49b3603f324a4afbf895d68b8d5485c71f1887769eabeb3499276c49e7102084234b4feb3853edb748aaa85f50
+  checksum: 10c0/41a099bb3705d96aac44b7a8db8805f2a22ce8a0f767a27b6d10b74a9964925df01c5f35d3631e882f8bcdeee3518884c30f40588ac8c960d88bf71048ba0df3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -545,7 +545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:1.19.11":
+"@hono/node-server@npm:1.19.14":
   version: 1.19.14
   resolution: "@hono/node-server@npm:1.19.14"
   peerDependencies:


### PR DESCRIPTION
## 内容

`package.json` に `resolutions` フィールドを追加し、`@hono/node-server` のバージョンを `1.19.14` に固定しました。

これにより、依存関係の解決時に `@hono/node-server` が常に指定されたバージョンで使用されるようになります。

## 動作確認項目

- [ ] `yarn install` でロックファイルが正しく更新されることを確認
- [ ] CI/CD パイプラインが正常に完了することを確認

## 関連するIssue

<!-- Issue番号があれば記入してください -->

https://claude.ai/code/session_011Hr3TmaBN5n3Xm9NufRsZS