### PR TITLE
SSRF対策: URLバリデーションを強化し非HTTPS・プライベートIPを拒否

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+package-lock.json
 
 # testing
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-package-lock.json
 
 # testing
 /coverage

--- a/src/app/books/register/actions.test.ts
+++ b/src/app/books/register/actions.test.ts
@@ -36,6 +36,23 @@ describe('server actions', () => {
       const now = new Date()
       const userId = user1.id
       const locationId = location1.id
+
+      // Google Books APIからサムネイルURLを返すようにモック
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              volumeInfo: {
+                imageLinks: {
+                  thumbnail: `https://books.google.com/books/content?id=test&zoom=1`,
+                },
+              },
+            },
+          ],
+        }),
+      })
+
       prismaMock.book.create.mockResolvedValueOnce({
         id: bookId,
         title,
@@ -52,14 +69,7 @@ describe('server actions', () => {
         createdAt: new Date(),
       })
 
-      const result = await registerBook(
-        title,
-        description,
-        isbn,
-        `https://example.com/books/${isbn}/external/cover.jpg`,
-        locationId,
-        userId,
-      )
+      const result = await registerBook(title, description, isbn, locationId, userId)
 
       expect(result).toBeUndefined()
       expect(prismaMock.book.create).toBeCalledWith({
@@ -88,12 +98,18 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
+      // サムネイルURLが取得できない場合のモック
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+
       const error = new Error('error has occurred')
       prismaMock.book.create.mockRejectedValueOnce(error)
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await expect(
-        registerBook(title, description, isbn, undefined, locationId, userId),
+        registerBook(title, description, isbn, locationId, userId),
       ).rejects.toThrow('Book creation failed')
 
       expect(prismaMock.book.create).toBeCalledWith({
@@ -118,6 +134,12 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
+      // サムネイルURLが取得できない場合のモック
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+
       const error = new Error('error has occurred')
       prismaMock.book.create.mockResolvedValueOnce({
         id: bookId,
@@ -131,7 +153,7 @@ describe('server actions', () => {
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await expect(
-        registerBook('testBook', 'テスト書籍の概要', '1234567890123', undefined, 1, user1.id),
+        registerBook('testBook', 'テスト書籍の概要', '1234567890123', 1, user1.id),
       ).rejects.toThrow('Registration creation failed')
 
       expect(prismaMock.book.create).toBeCalledWith({

--- a/src/app/books/register/actions.test.ts
+++ b/src/app/books/register/actions.test.ts
@@ -45,7 +45,7 @@ describe('server actions', () => {
             {
               volumeInfo: {
                 imageLinks: {
-                  thumbnail: `https://books.google.com/books/content?id=test&zoom=1`,
+                  thumbnail: 'https://books.google.com/books/content?id=test&zoom=1',
                 },
               },
             },
@@ -108,9 +108,9 @@ describe('server actions', () => {
       prismaMock.book.create.mockRejectedValueOnce(error)
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      await expect(
-        registerBook(title, description, isbn, locationId, userId),
-      ).rejects.toThrow('Book creation failed')
+      await expect(registerBook(title, description, isbn, locationId, userId)).rejects.toThrow(
+        'Book creation failed',
+      )
 
       expect(prismaMock.book.create).toBeCalledWith({
         data: {

--- a/src/app/books/register/actions.test.ts
+++ b/src/app/books/register/actions.test.ts
@@ -36,23 +36,6 @@ describe('server actions', () => {
       const now = new Date()
       const userId = user1.id
       const locationId = location1.id
-
-      // Google Books APIからサムネイルURLを返すようにモック
-      global.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            {
-              volumeInfo: {
-                imageLinks: {
-                  thumbnail: 'https://books.google.com/books/content?id=test&zoom=1',
-                },
-              },
-            },
-          ],
-        }),
-      })
-
       prismaMock.book.create.mockResolvedValueOnce({
         id: bookId,
         title,
@@ -69,7 +52,14 @@ describe('server actions', () => {
         createdAt: new Date(),
       })
 
-      const result = await registerBook(title, description, isbn, locationId, userId)
+      const result = await registerBook(
+        title,
+        description,
+        isbn,
+        `https://example.com/books/${isbn}/external/cover.jpg`,
+        locationId,
+        userId,
+      )
 
       expect(result).toBeUndefined()
       expect(prismaMock.book.create).toBeCalledWith({
@@ -98,19 +88,13 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
-      // サムネイルURLが取得できない場合のモック
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      })
-
       const error = new Error('error has occurred')
       prismaMock.book.create.mockRejectedValueOnce(error)
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      await expect(registerBook(title, description, isbn, locationId, userId)).rejects.toThrow(
-        'Book creation failed',
-      )
+      await expect(
+        registerBook(title, description, isbn, undefined, locationId, userId),
+      ).rejects.toThrow('Book creation failed')
 
       expect(prismaMock.book.create).toBeCalledWith({
         data: {
@@ -134,12 +118,6 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
-      // サムネイルURLが取得できない場合のモック
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      })
-
       const error = new Error('error has occurred')
       prismaMock.book.create.mockResolvedValueOnce({
         id: bookId,
@@ -153,7 +131,7 @@ describe('server actions', () => {
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await expect(
-        registerBook('testBook', 'テスト書籍の概要', '1234567890123', 1, user1.id),
+        registerBook('testBook', 'テスト書籍の概要', '1234567890123', undefined, 1, user1.id),
       ).rejects.toThrow('Registration creation failed')
 
       expect(prismaMock.book.create).toBeCalledWith({

--- a/src/app/books/register/actions.test.ts
+++ b/src/app/books/register/actions.test.ts
@@ -52,14 +52,23 @@ describe('server actions', () => {
         createdAt: new Date(),
       })
 
-      const result = await registerBook(
-        title,
-        description,
-        isbn,
-        `https://example.com/books/${isbn}/external/cover.jpg`,
-        locationId,
-        userId,
-      )
+      // Google Books APIからサムネイルURLを返すようにモック
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              volumeInfo: {
+                imageLinks: {
+                  thumbnail: 'https://books.google.com/books/content?id=test&zoom=1',
+                },
+              },
+            },
+          ],
+        }),
+      })
+
+      const result = await registerBook(title, description, isbn, locationId, userId)
 
       expect(result).toBeUndefined()
       expect(prismaMock.book.create).toBeCalledWith({
@@ -88,13 +97,19 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
+      // サムネイルURLが取得できない場合のモック
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+
       const error = new Error('error has occurred')
       prismaMock.book.create.mockRejectedValueOnce(error)
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      await expect(
-        registerBook(title, description, isbn, undefined, locationId, userId),
-      ).rejects.toThrow('Book creation failed')
+      await expect(registerBook(title, description, isbn, locationId, userId)).rejects.toThrow(
+        'Book creation failed',
+      )
 
       expect(prismaMock.book.create).toBeCalledWith({
         data: {
@@ -118,6 +133,12 @@ describe('server actions', () => {
       const userId = user1.id
       const locationId = location1.id
 
+      // サムネイルURLが取得できない場合のモック
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+
       const error = new Error('error has occurred')
       prismaMock.book.create.mockResolvedValueOnce({
         id: bookId,
@@ -131,7 +152,7 @@ describe('server actions', () => {
       const errorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await expect(
-        registerBook('testBook', 'テスト書籍の概要', '1234567890123', undefined, 1, user1.id),
+        registerBook('testBook', 'テスト書籍の概要', '1234567890123', 1, user1.id),
       ).rejects.toThrow('Registration creation failed')
 
       expect(prismaMock.book.create).toBeCalledWith({

--- a/src/app/books/register/actions.ts
+++ b/src/app/books/register/actions.ts
@@ -1,16 +1,52 @@
 'use server'
 
 import { redirect } from 'next/navigation'
+import { GOOGLE_BOOK_SEARCH_QUERY, OPENBD_SEARCH_QUERY } from '@/constants'
 import prisma from '@/libs/prisma/client'
 import { notifySlack } from '@/libs/slack/webhook'
 import { downloadAndPutImage } from '@/libs/vercel/downloadAndPutImage'
+
+type GoogleBooksResponse = {
+  items?: Array<{
+    volumeInfo?: {
+      imageLinks?: {
+        thumbnail?: string
+      }
+    }
+  }>
+}
+
+type OpenBDResponse = Array<{
+  summary?: {
+    cover?: string
+  }
+} | null>
+
+/** ISBNを使ってサーバーサイドでサムネイルURLを取得する */
+const fetchThumbnailUrl = async (isbn: string): Promise<string | undefined> => {
+  try {
+    const googleRes = await fetch(`${GOOGLE_BOOK_SEARCH_QUERY}${isbn}`)
+    const googleData: GoogleBooksResponse = await googleRes.json()
+    const thumbnail = googleData?.items?.[0]?.volumeInfo?.imageLinks?.thumbnail
+    if (thumbnail) return thumbnail
+  } catch {
+    // フォールバックに進む
+  }
+
+  try {
+    const openbdRes = await fetch(`${OPENBD_SEARCH_QUERY}${isbn}`)
+    const openbdData: OpenBDResponse = await openbdRes.json()
+    return openbdData?.[0]?.summary?.cover ?? undefined
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * 書籍登録をするServer Action
  * @param {string} title
  * @param description
  * @param {string} isbn
- * @param {string | undefined} imageUrl
  * @param {number} locationId
  * @param {number} userId
  * @returns {Promise<void>}
@@ -19,10 +55,11 @@ export const registerBook = async (
   title: string,
   description: string,
   isbn: string,
-  imageUrl: string | undefined,
   locationId: number,
   userId: number,
 ): Promise<void> => {
+  // ユーザー提供URLを使わず、ISBNからサーバーサイドでサムネイルURLを取得（SSRF対策）
+  const imageUrl = await fetchThumbnailUrl(isbn)
   const vercelBlobUrl = await downloadAndPutImage(imageUrl, isbn)
 
   const book = await prisma.book

--- a/src/app/books/register/actions.ts
+++ b/src/app/books/register/actions.ts
@@ -1,52 +1,16 @@
 'use server'
 
 import { redirect } from 'next/navigation'
-import { GOOGLE_BOOK_SEARCH_QUERY, OPENBD_SEARCH_QUERY } from '@/constants'
 import prisma from '@/libs/prisma/client'
 import { notifySlack } from '@/libs/slack/webhook'
 import { downloadAndPutImage } from '@/libs/vercel/downloadAndPutImage'
-
-type GoogleBooksResponse = {
-  items?: Array<{
-    volumeInfo?: {
-      imageLinks?: {
-        thumbnail?: string
-      }
-    }
-  }>
-}
-
-type OpenBDResponse = Array<{
-  summary?: {
-    cover?: string
-  }
-} | null>
-
-/** ISBNを使ってサーバーサイドでサムネイルURLを取得する */
-const fetchThumbnailUrl = async (isbn: string): Promise<string | undefined> => {
-  try {
-    const googleRes = await fetch(`${GOOGLE_BOOK_SEARCH_QUERY}${isbn}`)
-    const googleData: GoogleBooksResponse = await googleRes.json()
-    const thumbnail = googleData?.items?.[0]?.volumeInfo?.imageLinks?.thumbnail
-    if (thumbnail) return thumbnail
-  } catch {
-    // フォールバックに進む
-  }
-
-  try {
-    const openbdRes = await fetch(`${OPENBD_SEARCH_QUERY}${isbn}`)
-    const openbdData: OpenBDResponse = await openbdRes.json()
-    return openbdData?.[0]?.summary?.cover ?? undefined
-  } catch {
-    return undefined
-  }
-}
 
 /**
  * 書籍登録をするServer Action
  * @param {string} title
  * @param description
  * @param {string} isbn
+ * @param {string | undefined} imageUrl
  * @param {number} locationId
  * @param {number} userId
  * @returns {Promise<void>}
@@ -55,11 +19,10 @@ export const registerBook = async (
   title: string,
   description: string,
   isbn: string,
+  imageUrl: string | undefined,
   locationId: number,
   userId: number,
 ): Promise<void> => {
-  // ユーザー提供URLを使わず、ISBNからサーバーサイドでサムネイルURLを取得（SSRF対策）
-  const imageUrl = await fetchThumbnailUrl(isbn)
   const vercelBlobUrl = await downloadAndPutImage(imageUrl, isbn)
 
   const book = await prisma.book

--- a/src/app/books/register/registerBookDiv.test.tsx
+++ b/src/app/books/register/registerBookDiv.test.tsx
@@ -22,14 +22,7 @@ describe('register book div component', async () => {
     const isbn = '1234567890123'
     const userId = user1.id
 
-    render(
-      <RegisterBookDiv
-        title={title}
-        description={description}
-        isbn={isbn}
-        userId={userId}
-      />,
-    )
+    render(<RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />)
 
     expect(registerBookActionMock).not.toBeCalled()
 
@@ -41,13 +34,7 @@ describe('register book div component', async () => {
 
     await waitFor(() => {
       expect(registerBookActionMock).toBeCalledTimes(1)
-      expect(registerBookActionMock).toHaveBeenCalledWith(
-        title,
-        description,
-        isbn,
-        1,
-        userId,
-      )
+      expect(registerBookActionMock).toHaveBeenCalledWith(title, description, isbn, 1, userId)
     })
   })
 })

--- a/src/app/books/register/registerBookDiv.test.tsx
+++ b/src/app/books/register/registerBookDiv.test.tsx
@@ -20,18 +20,9 @@ describe('register book div component', async () => {
     const title = 'testBook'
     const description = 'テスト書籍の概要'
     const isbn = '1234567890123'
-    const thumbnailUrl = 'https://example.com/test.jpg'
     const userId = user1.id
 
-    render(
-      <RegisterBookDiv
-        title={title}
-        description={description}
-        isbn={isbn}
-        thumbnailUrl={thumbnailUrl}
-        userId={userId}
-      />,
-    )
+    render(<RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />)
 
     expect(registerBookActionMock).not.toBeCalled()
 
@@ -43,14 +34,7 @@ describe('register book div component', async () => {
 
     await waitFor(() => {
       expect(registerBookActionMock).toBeCalledTimes(1)
-      expect(registerBookActionMock).toHaveBeenCalledWith(
-        title,
-        description,
-        isbn,
-        thumbnailUrl,
-        1,
-        userId,
-      )
+      expect(registerBookActionMock).toHaveBeenCalledWith(title, description, isbn, 1, userId)
     })
   })
 })

--- a/src/app/books/register/registerBookDiv.test.tsx
+++ b/src/app/books/register/registerBookDiv.test.tsx
@@ -20,7 +20,6 @@ describe('register book div component', async () => {
     const title = 'testBook'
     const description = 'テスト書籍の概要'
     const isbn = '1234567890123'
-    const thumbnailUrl = 'https://example.com/test.jpg'
     const userId = user1.id
 
     render(
@@ -28,7 +27,6 @@ describe('register book div component', async () => {
         title={title}
         description={description}
         isbn={isbn}
-        thumbnailUrl={thumbnailUrl}
         userId={userId}
       />,
     )
@@ -47,7 +45,6 @@ describe('register book div component', async () => {
         title,
         description,
         isbn,
-        thumbnailUrl,
         1,
         userId,
       )

--- a/src/app/books/register/registerBookDiv.test.tsx
+++ b/src/app/books/register/registerBookDiv.test.tsx
@@ -20,9 +20,18 @@ describe('register book div component', async () => {
     const title = 'testBook'
     const description = 'テスト書籍の概要'
     const isbn = '1234567890123'
+    const thumbnailUrl = 'https://example.com/test.jpg'
     const userId = user1.id
 
-    render(<RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />)
+    render(
+      <RegisterBookDiv
+        title={title}
+        description={description}
+        isbn={isbn}
+        thumbnailUrl={thumbnailUrl}
+        userId={userId}
+      />,
+    )
 
     expect(registerBookActionMock).not.toBeCalled()
 
@@ -34,7 +43,14 @@ describe('register book div component', async () => {
 
     await waitFor(() => {
       expect(registerBookActionMock).toBeCalledTimes(1)
-      expect(registerBookActionMock).toHaveBeenCalledWith(title, description, isbn, 1, userId)
+      expect(registerBookActionMock).toHaveBeenCalledWith(
+        title,
+        description,
+        isbn,
+        thumbnailUrl,
+        1,
+        userId,
+      )
     })
   })
 })

--- a/src/app/books/register/registerBookDiv.tsx
+++ b/src/app/books/register/registerBookDiv.tsx
@@ -11,7 +11,6 @@ type RegisterBookDivProps = {
   title: string
   description: string
   isbn: string
-  thumbnailUrl: string | undefined
   userId: number
 }
 
@@ -20,7 +19,6 @@ type RegisterBookDivProps = {
  * @param {string} title
  * @param {string} description
  * @param {string} isbn
- * @param {string | undefined} thumbnailUrl
  * @param {number} userId
  * @returns {JSX.Element}
  * @constructor
@@ -29,7 +27,6 @@ const RegisterBookDiv: FC<RegisterBookDivProps> = ({
   title,
   description,
   isbn,
-  thumbnailUrl,
   userId,
 }) => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null)
@@ -50,7 +47,7 @@ const RegisterBookDiv: FC<RegisterBookDivProps> = ({
       alert('保管場所を選択してください')
       return
     }
-    await registerBook(title, description, isbn, thumbnailUrl, selectedLocationId, userId)
+    await registerBook(title, description, isbn, selectedLocationId, userId)
   }
 
   return (

--- a/src/app/books/register/registerBookDiv.tsx
+++ b/src/app/books/register/registerBookDiv.tsx
@@ -23,12 +23,7 @@ type RegisterBookDivProps = {
  * @returns {JSX.Element}
  * @constructor
  */
-const RegisterBookDiv: FC<RegisterBookDivProps> = ({
-  title,
-  description,
-  isbn,
-  userId,
-}) => {
+const RegisterBookDiv: FC<RegisterBookDivProps> = ({ title, description, isbn, userId }) => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null)
 
   const { data: locationsData, error } = useSWR<{ locations: Location[] } | CustomError>(

--- a/src/app/books/register/registerBookDiv.tsx
+++ b/src/app/books/register/registerBookDiv.tsx
@@ -11,7 +11,6 @@ type RegisterBookDivProps = {
   title: string
   description: string
   isbn: string
-  thumbnailUrl: string | undefined
   userId: number
 }
 
@@ -20,18 +19,11 @@ type RegisterBookDivProps = {
  * @param {string} title
  * @param {string} description
  * @param {string} isbn
- * @param {string | undefined} thumbnailUrl
  * @param {number} userId
  * @returns {JSX.Element}
  * @constructor
  */
-const RegisterBookDiv: FC<RegisterBookDivProps> = ({
-  title,
-  description,
-  isbn,
-  thumbnailUrl,
-  userId,
-}) => {
+const RegisterBookDiv: FC<RegisterBookDivProps> = ({ title, description, isbn, userId }) => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null)
 
   const { data: locationsData, error } = useSWR<{ locations: Location[] } | CustomError>(
@@ -50,7 +42,7 @@ const RegisterBookDiv: FC<RegisterBookDivProps> = ({
       alert('保管場所を選択してください')
       return
     }
-    await registerBook(title, description, isbn, thumbnailUrl, selectedLocationId, userId)
+    await registerBook(title, description, isbn, selectedLocationId, userId)
   }
 
   return (

--- a/src/app/books/register/registerBookDiv.tsx
+++ b/src/app/books/register/registerBookDiv.tsx
@@ -11,6 +11,7 @@ type RegisterBookDivProps = {
   title: string
   description: string
   isbn: string
+  thumbnailUrl: string | undefined
   userId: number
 }
 
@@ -19,11 +20,18 @@ type RegisterBookDivProps = {
  * @param {string} title
  * @param {string} description
  * @param {string} isbn
+ * @param {string | undefined} thumbnailUrl
  * @param {number} userId
  * @returns {JSX.Element}
  * @constructor
  */
-const RegisterBookDiv: FC<RegisterBookDivProps> = ({ title, description, isbn, userId }) => {
+const RegisterBookDiv: FC<RegisterBookDivProps> = ({
+  title,
+  description,
+  isbn,
+  thumbnailUrl,
+  userId,
+}) => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null)
 
   const { data: locationsData, error } = useSWR<{ locations: Location[] } | CustomError>(
@@ -42,7 +50,7 @@ const RegisterBookDiv: FC<RegisterBookDivProps> = ({ title, description, isbn, u
       alert('保管場所を選択してください')
       return
     }
-    await registerBook(title, description, isbn, selectedLocationId, userId)
+    await registerBook(title, description, isbn, thumbnailUrl, selectedLocationId, userId)
   }
 
   return (

--- a/src/app/books/register/searchedBook.tsx
+++ b/src/app/books/register/searchedBook.tsx
@@ -63,11 +63,17 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
       description: publicBook.description,
       imageUrl: publicBook.imageUrl,
     }
-    const { title, description } = publicBook
+    const { title, description, imageUrl: thumbnailUrl } = publicBook
     return (
       <>
         <FoundBookDiv book={book} />
-        <RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />
+        <RegisterBookDiv
+          title={title}
+          description={description}
+          isbn={isbn}
+          thumbnailUrl={thumbnailUrl}
+          userId={userId}
+        />
       </>
     )
   }

--- a/src/app/books/register/searchedBook.tsx
+++ b/src/app/books/register/searchedBook.tsx
@@ -67,12 +67,7 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
     return (
       <>
         <FoundBookDiv book={book} />
-        <RegisterBookDiv
-          title={title}
-          description={description}
-          isbn={isbn}
-          userId={userId}
-        />
+        <RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />
       </>
     )
   }

--- a/src/app/books/register/searchedBook.tsx
+++ b/src/app/books/register/searchedBook.tsx
@@ -63,7 +63,7 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
       description: publicBook.description,
       imageUrl: publicBook.imageUrl,
     }
-    const { title, description, imageUrl: thumbnailUrl } = publicBook
+    const { title, description } = publicBook
     return (
       <>
         <FoundBookDiv book={book} />
@@ -71,7 +71,6 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
           title={title}
           description={description}
           isbn={isbn}
-          thumbnailUrl={thumbnailUrl}
           userId={userId}
         />
       </>

--- a/src/app/books/register/searchedBook.tsx
+++ b/src/app/books/register/searchedBook.tsx
@@ -63,17 +63,11 @@ const SearchedBook: FC<SearchedBookProps> = ({ isbn, userId }) => {
       description: publicBook.description,
       imageUrl: publicBook.imageUrl,
     }
-    const { title, description, imageUrl: thumbnailUrl } = publicBook
+    const { title, description } = publicBook
     return (
       <>
         <FoundBookDiv book={book} />
-        <RegisterBookDiv
-          title={title}
-          description={description}
-          isbn={isbn}
-          thumbnailUrl={thumbnailUrl}
-          userId={userId}
-        />
+        <RegisterBookDiv title={title} description={description} isbn={isbn} userId={userId} />
       </>
     )
   }

--- a/src/libs/vercel/downloadAndPutImage.test.ts
+++ b/src/libs/vercel/downloadAndPutImage.test.ts
@@ -124,4 +124,37 @@ describe('downloadAndPutImage function', () => {
     expect(putMock).not.toHaveBeenCalled()
     expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
   })
+
+  it('IPv6ループバックアドレス（[::1]）のURLはブラケット付きでも拒否される', async () => {
+    const externalImageUrl = 'https://[::1]/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('IPv6リンクローカルアドレス（[fe80::1]）のURLは拒否される', async () => {
+    const externalImageUrl = 'https://[fe80::1]/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('0.0.0.0/8範囲のIPアドレスのURLは拒否される', async () => {
+    const externalImageUrl = 'https://0.0.0.1/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
 })

--- a/src/libs/vercel/downloadAndPutImage.test.ts
+++ b/src/libs/vercel/downloadAndPutImage.test.ts
@@ -69,4 +69,59 @@ describe('downloadAndPutImage function', () => {
     expect(putMock).not.toHaveBeenCalled()
     expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
   })
+
+  it('HTTPSでないURLは拒否される', async () => {
+    const externalImageUrl = 'http://example.net/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('プライベートIPアドレス（192.168.x.x）のURLは拒否される', async () => {
+    const externalImageUrl = 'https://192.168.1.1/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('ループバックアドレス（127.0.0.1）のURLは拒否される', async () => {
+    const externalImageUrl = 'https://127.0.0.1/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('リンクローカルアドレス（169.254.169.254）のURLは拒否される', async () => {
+    const externalImageUrl = 'https://169.254.169.254/latest/meta-data/'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
+
+  it('localhostのURLは拒否される', async () => {
+    const externalImageUrl = 'https://localhost/image.jpg'
+    const isbn = '1234567890'
+
+    const result = await downloadAndPutImage(externalImageUrl, isbn)
+
+    expect(result).toBeUndefined()
+    expect(putMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(`不正な画像URL: ${externalImageUrl}`)
+  })
 })

--- a/src/libs/vercel/downloadAndPutImage.ts
+++ b/src/libs/vercel/downloadAndPutImage.ts
@@ -11,21 +11,49 @@ const getAllowedHosts = (): string[] => {
     .filter((hostname): hostname is string => Boolean(hostname))
 }
 
+// プライベートIPアドレス・ループバック・リンクローカルのパターン（SSRF対策）
+const PRIVATE_IP_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^0\.0\.0\.0$/,
+  /^10\./,
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^fc[0-9a-f]{2}:/i,
+  /^fd[0-9a-f]{2}:/i,
+]
+
+const isPrivateIpOrLocalhost = (hostname: string): boolean => {
+  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(hostname))
+}
+
 /**
- * URLが信頼できるホストからのものかを検証する
+ * URLを検証し、安全な場合は正規化されたURLオブジェクトを返す
+ * SSRF攻撃を防ぐため、HTTPSかつ許可されたホストのみを受け入れる
  * @param {string} url 検証するURL
- * @returns {boolean} 信頼できるホストの場合true
+ * @returns {URL | null} 有効なURLオブジェクト、無効な場合はnull
  */
-const isAllowedImageUrl = (url: string): boolean => {
+const validateImageUrl = (url: string): URL | null => {
   try {
     const parsedUrl = new URL(url)
+
+    // HTTPSのみ許可（fileやhttpなどのプロトコルを拒否）
+    if (parsedUrl.protocol !== 'https:') return null
+
     const hostname = parsedUrl.hostname
-    const allowedHosts = getAllowedHosts()
+
+    // プライベートIPアドレス・localhostを拒否（内部ネットワークへのアクセスを防止）
+    if (isPrivateIpOrLocalhost(hostname)) return null
 
     // セキュリティの観点で、現在の実装ではワイルドカード（*.example.org）はサポートしない
-    return allowedHosts.includes(hostname)
+    const allowedHosts = getAllowedHosts()
+    if (!allowedHosts.includes(hostname)) return null
+
+    return parsedUrl
   } catch {
-    return false
+    return null
   }
 }
 
@@ -43,13 +71,15 @@ export const downloadAndPutImage = async (
     return undefined
   }
 
-  // SSRF攻撃を防ぐため、信頼できるホストのみ許可
-  if (!isAllowedImageUrl(externalImageUrl)) {
+  // SSRF攻撃を防ぐため、検証済みのURLオブジェクトを取得
+  const validatedUrl = validateImageUrl(externalImageUrl)
+  if (!validatedUrl) {
     console.warn(`不正な画像URL: ${externalImageUrl}`)
     return undefined
   }
 
-  const imageFile = await fetch(externalImageUrl).then((res) => res.blob())
+  // 正規化された検証済みURLを使用してフェッチ（生の入力文字列を使わない）
+  const imageFile = await fetch(validatedUrl.href).then((res) => res.blob())
   const blob = await put(`cover/${isbn}.jpg`, imageFile, {
     access: 'public',
     contentType: 'image/jpeg',

--- a/src/libs/vercel/downloadAndPutImage.ts
+++ b/src/libs/vercel/downloadAndPutImage.ts
@@ -15,7 +15,7 @@ const getAllowedHosts = (): string[] => {
 const PRIVATE_IP_PATTERNS = [
   /^localhost$/i,
   /^127\./,
-  /^0\.0\.0\.0$/,
+  /^0\./,
   /^10\./,
   /^172\.(1[6-9]|2[0-9]|3[01])\./,
   /^192\.168\./,
@@ -23,6 +23,7 @@ const PRIVATE_IP_PATTERNS = [
   /^::1$/,
   /^fc[0-9a-f]{2}:/i,
   /^fd[0-9a-f]{2}:/i,
+  /^fe[89ab][0-9a-f]:/i,
 ]
 
 const isPrivateIpOrLocalhost = (hostname: string): boolean => {
@@ -42,14 +43,15 @@ const validateImageUrl = (url: string): URL | null => {
     // HTTPSのみ許可（fileやhttpなどのプロトコルを拒否）
     if (parsedUrl.protocol !== 'https:') return null
 
-    const hostname = parsedUrl.hostname
+    // IPv6アドレスのブラケットを除去して正規化（例: "[::1]" → "::1"）
+    const cleanHostname = parsedUrl.hostname.replace(/^\[|\]$/g, '')
 
     // プライベートIPアドレス・localhostを拒否（内部ネットワークへのアクセスを防止）
-    if (isPrivateIpOrLocalhost(hostname)) return null
+    if (isPrivateIpOrLocalhost(cleanHostname)) return null
 
     // セキュリティの観点で、現在の実装ではワイルドカード（*.example.org）はサポートしない
     const allowedHosts = getAllowedHosts()
-    if (!allowedHosts.includes(hostname)) return null
+    if (!allowedHosts.includes(cleanHostname)) return null
 
     return parsedUrl
   } catch {


### PR DESCRIPTION
## 内容

`downloadAndPutImage`関数のURLバリデーション機能を強化し、SSRF（Server-Side Request Forgery）攻撃への対策を実装しました。

### 主な変更点

1. **URLバリデーション関数の改善**
   - `isAllowedImageUrl`から`validateImageUrl`に変更し、検証済みのURLオブジェクトを返すように改善
   - HTTPSプロトコルのみを許可（httpやfileなどを拒否）
   - 正規化されたURLを使用してフェッチを実行

2. **プライベートIPアドレス・ローカルホストの拒否**
   - `PRIVATE_IP_PATTERNS`正規表現パターンを追加
   - 以下のアドレスを拒否：
     - ループバックアドレス（127.0.0.1、::1）
     - プライベートIPレンジ（10.0.0.0/8、172.16.0.0/12、192.168.0.0/16）
     - リンクローカルアドレス（169.254.0.0/16）
     - IPv6プライベートアドレス（fc00::/7、fd00::/8）
     - localhost

3. **テストケースの追加**
   - HTTPSでないURL（http://）の拒否テスト
   - プライベートIPアドレス（192.168.x.x）の拒否テスト
   - ループバックアドレス（127.0.0.1）の拒否テスト
   - リンクローカルアドレス（169.254.169.254）の拒否テスト
   - localhostの拒否テスト

## 動作確認項目

- ✅ 新規追加テストケース5件がすべてパス
- ✅ 既存テストケースがすべてパス
- ✅ HTTPSかつ許可されたホストからのURLは正常に処理される
- ✅ 不正なURLはすべて拒否され、警告ログが出力される

## 関連するIssue

SSRF脆弱性対策

https://claude.ai/code/session_01UauofsX2pDRion1bKpmbF9