### PR TITLE
E2Eテストのコンテナ構成を簡素化

### DIFF
--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -63,7 +63,7 @@ jobs:
         # ダウンロードが stall（無応答停止）することがあるため、timeout で打ち切りつつリトライする。
         run: |
           for i in 1 2 3; do
-            timeout 300 yarn playwright install --with-deps chromium && exit 0
+            timeout 300 npx playwright install --with-deps chromium && exit 0
             echo "Playwrightのインストールが失敗またはタイムアウトしました。リトライ ${i}/3..."
             sleep 5
           done

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -49,9 +49,26 @@ jobs:
       - name: 依存関係をインストール
         run: yarn install --immutable
 
+      # Playwrightのブラウザバイナリをキャッシュし、2回目以降はダウンロード自体をスキップする。
+      # キーは yarn.lock（= Playwrightバージョン）に紐づける。
+      - name: Playwrightブラウザのキャッシュ
+        id: playwright-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}
+
       - name: Playwrightブラウザをインストール
-        # 使用するのは chromium プロジェクトのみのため、全ブラウザではなく chromium だけを入れる
-        run: yarn playwright install --with-deps chromium
+        # 使用するのは chromium プロジェクトのみのため、全ブラウザではなく chromium だけを入れる。
+        # ダウンロードが stall（無応答停止）することがあるため、timeout で打ち切りつつリトライする。
+        run: |
+          for i in 1 2 3; do
+            timeout 300 yarn playwright install --with-deps chromium && exit 0
+            echo "Playwrightのインストールが失敗またはタイムアウトしました。リトライ ${i}/3..."
+            sleep 5
+          done
+          echo "Playwrightのインストールに3回失敗しました" >&2
+          exit 1
 
       - name: Prismaクライアントを生成
         run: yarn db:generate

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -62,6 +62,10 @@ jobs:
       - name: シードデータを投入
         run: yarn tsx prisma/seed.ts
 
+      - name: アプリをビルド
+        # CIのE2Eは yarn start（本番サーバー）で起動するため事前ビルドが必要
+        run: yarn build
+
       - name: E2Eテストを実行
         run: yarn e2e
 

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -9,10 +9,6 @@ permissions:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    # Playwrightブラウザが事前インストール済みのイメージを使用し、
-    # Chrome ダウンロードによる時間超過を回避する
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
 
     services:
       postgres:
@@ -20,6 +16,8 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgrespassword
           POSTGRES_DB: e2e_test
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -32,9 +30,9 @@ jobs:
       NEXTAUTH_URL: http://localhost:3000
       NEXT_PUBLIC_DEFAULT_PROVIDER: credentials
       # データベース（CI用ローカルPostgreSQL）
-      # コンテナジョブではサービスにはサービス名（postgres）でアクセスする
-      POSTGRES_PRISMA_URL: postgresql://postgres:postgrespassword@postgres:5432/e2e_test?sslmode=disable
-      POSTGRES_URL_NON_POOLING: postgresql://postgres:postgrespassword@postgres:5432/e2e_test?sslmode=disable
+      # コンテナを使わないジョブではサービスに localhost でアクセスする
+      POSTGRES_PRISMA_URL: postgresql://postgres:postgrespassword@localhost:5432/e2e_test?sslmode=disable
+      POSTGRES_URL_NON_POOLING: postgresql://postgres:postgrespassword@localhost:5432/e2e_test?sslmode=disable
       # Azure AD（E2Eでは credentials プロバイダーを使用するため未使用だが起動エラー防止のため設定）
       AZURE_AD_TENANT_ID: dummy-tenant-id
       AZURE_AD_CLIENT_ID: dummy-client-id
@@ -50,6 +48,9 @@ jobs:
 
       - name: 依存関係をインストール
         run: yarn install --immutable
+
+      - name: Playwrightブラウザをインストール
+        run: yarn playwright install --with-deps
 
       - name: Prismaクライアントを生成
         run: yarn db:generate

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -1,7 +1,8 @@
 name: e2eTest
 
 on:
-  pull_request
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -49,26 +49,9 @@ jobs:
       - name: 依存関係をインストール
         run: yarn install --immutable
 
-      # Playwrightのブラウザバイナリをキャッシュし、2回目以降はダウンロード自体をスキップする。
-      # キーは yarn.lock（= Playwrightバージョン）に紐づける。
-      - name: Playwrightブラウザのキャッシュ
-        id: playwright-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}
-
       - name: Playwrightブラウザをインストール
-        # 使用するのは chromium プロジェクトのみのため、全ブラウザではなく chromium だけを入れる。
-        # ダウンロードが stall（無応答停止）することがあるため、timeout で打ち切りつつリトライする。
-        run: |
-          for i in 1 2 3; do
-            timeout 300 npx playwright install --with-deps chromium && exit 0
-            echo "Playwrightのインストールが失敗またはタイムアウトしました。リトライ ${i}/3..."
-            sleep 5
-          done
-          echo "Playwrightのインストールに3回失敗しました" >&2
-          exit 1
+        # 使用するのは chromium プロジェクトのみのため、全ブラウザではなく chromium だけを入れる
+        run: npx playwright install --with-deps chromium
 
       - name: Prismaクライアントを生成
         run: yarn db:generate
@@ -78,10 +61,6 @@ jobs:
 
       - name: シードデータを投入
         run: yarn tsx prisma/seed.ts
-
-      - name: アプリをビルド
-        # CIのE2Eは yarn start（本番サーバー）で起動するため事前ビルドが必要
-        run: yarn build
 
       - name: E2Eテストを実行
         run: yarn e2e

--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -50,7 +50,8 @@ jobs:
         run: yarn install --immutable
 
       - name: Playwrightブラウザをインストール
-        run: yarn playwright install --with-deps
+        # 使用するのは chromium プロジェクトのみのため、全ブラウザではなく chromium だけを入れる
+        run: yarn playwright install --with-deps chromium
 
       - name: Prismaクライアントを生成
         run: yarn db:generate

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'yarn dev',
+    // CIでは事前にビルドした本番サーバー（yarn start）を使う。開発サーバー（yarn dev）は
+    // 初回リクエスト時のルート逐次コンパイルが遅く、CIでテストがタイムアウトしてジョブが
+    // 止まって見えるため、CIでのみ本番ビルド方式に切り替える（ローカルは yarn dev のまま）。
+    command: process.env.CI ? 'yarn start' : 'yarn dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,10 +37,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    // CIでは事前にビルドした本番サーバー（yarn start）を使う。開発サーバー（yarn dev）は
-    // 初回リクエスト時のルート逐次コンパイルが遅く、CIでテストがタイムアウトしてジョブが
-    // 止まって見えるため、CIでのみ本番ビルド方式に切り替える（ローカルは yarn dev のまま）。
-    command: process.env.CI ? 'yarn start' : 'yarn dev',
+    command: 'yarn dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,14 +933,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.59.1":
-  version: 1.59.1
-  resolution: "@playwright/test@npm:1.59.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    playwright: "npm:1.59.1"
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10c0/8c2d94a860d3c254a0b114df2f888ad0a0e9310f45b6059bd5d4da196d965cadf6922267cef0881cfa9784d4bef6d78363d2c2d94caa64be67ff644c41162137
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
   languageName: node
   linkType: hard
 
@@ -2220,7 +2220,7 @@ __metadata:
   resolution: "company-library@workspace:."
   dependencies:
     "@biomejs/biome": "npm:^2.4.16"
-    "@playwright/test": "npm:1.59.1"
+    "@playwright/test": "npm:^1.60.0"
     "@prisma/adapter-pg": "npm:^7.8.0"
     "@prisma/client": "npm:^7.8.0"
     "@slack/webhook": "npm:^7.0.9"
@@ -3914,27 +3914,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright-core@npm:1.59.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/d41a74d9681ce3beb3d5239e9ed577710b4ad099a6ca2476219c6599d51e9cb4b80bd72ed82c528da6a5d929c18ae3b872cf02bb83f78fa1c2cb9199c501abee
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
   languageName: node
   linkType: hard
 
-"playwright@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright@npm:1.59.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.59.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/dfe38396e616e5c4f98825ce90037bb96e477c5a2bd9258a24854f8ce72a8a41427b19098863866f85aa0216e70287dd537c4438d761aca93995e31ae099c533
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 内容

GitHub ActionsのE2Eテストワークフローから事前ビルド済みPlaywrightコンテナイメージの使用を廃止し、通常のランナー上でブラウザを都度インストールする構成に変更しました（[Playwright公式CIガイド](https://playwright.dev/docs/ci#github-actions)に準拠）。

### 変更点

- **Playwrightコンテナの削除**: `mcr.microsoft.com/playwright:v1.59.1-noble` コンテナイメージの使用を廃止し、`ubuntu-latest` ランナー上で直接実行
- **Playwrightブラウザのインストールステップを追加**: `npx playwright install --with-deps chromium`（使用するchromiumのみに限定）
- **PostgreSQLサービスのポート公開**: `ports: 5432:5432` を追加し、ホストランナーからアクセス可能に
- **データベース接続先の変更**: コンテナジョブではなくなったため、サービスホスト名を `postgres` → `localhost` に変更
- **`@playwright/test` を 1.59.1 → 1.60.0 へ更新**: 旧バージョンではCIでブラウザ（Chrome for Testing）のダウンロードが stall してジョブが終わらない問題があったため、最新版へ追従して解消

## 補足

- E2Eの実行は従来どおり `yarn e2e`（webServerは `yarn dev`）。本番ビルド方式への切り替えやキャッシュ等の回避策は、バージョン更新で根本解決したため導入していません。

## 動作確認項目

- [ ] Playwrightブラウザが正常にインストールされる（DLが stall しない）
- [ ] PostgreSQLへの接続が確立される
- [ ] E2Eテスト（認証セットアップ含む）が正常に実行される
- [ ] CI/CDパイプラインが成功する

https://claude.ai/code/session_01YJVdJhWEVVnjuWBBuXvDUZ