### PR TITLE
fix: imageUrl未設定時のno_image.jpgにunoptimizedを追加

### DIFF
--- a/src/app/books/[id]/bookDetail.test.tsx
+++ b/src/app/books/[id]/bookDetail.test.tsx
@@ -94,7 +94,7 @@ describe('BookDetail component', () => {
     expect(screen.getByAltText(book.title)).toBeInTheDocument()
     expect(screen.getByAltText(book.title)).toHaveAttribute(
       'src',
-      expect.stringContaining(encodeURIComponent('/no_image.jpg')),
+      '/no_image.jpg',
     )
   })
 

--- a/src/app/books/[id]/bookDetail.test.tsx
+++ b/src/app/books/[id]/bookDetail.test.tsx
@@ -92,10 +92,7 @@ describe('BookDetail component', () => {
     })
 
     expect(screen.getByAltText(book.title)).toBeInTheDocument()
-    expect(screen.getByAltText(book.title)).toHaveAttribute(
-      'src',
-      '/no_image.jpg',
-    )
+    expect(screen.getByAltText(book.title)).toHaveAttribute('src', '/no_image.jpg')
   })
 
   it('貸し出し可能数は、場所ごとに正しい所蔵数が表示される', async () => {

--- a/src/app/books/[id]/bookDetail.tsx
+++ b/src/app/books/[id]/bookDetail.tsx
@@ -119,6 +119,7 @@ const BookDetail: FC<BookDetailProps> = async ({ bookId, userId }) => {
       <div className="w-full lg:w-1/2">
         <Image
           src={bookDetail.imageUrl ? bookDetail.imageUrl : '/no_image.jpg'}
+          unoptimized={!bookDetail.imageUrl}
           alt={bookDetail.title}
           width={300}
           height={400}

--- a/src/components/bookTile.test.tsx
+++ b/src/components/bookTile.test.tsx
@@ -20,7 +20,7 @@ describe('book component', () => {
     expect(getByText(bookWithoutImage.title)).toBeInTheDocument()
     expect(getByTestId('bookImg')).toHaveAttribute(
       'src',
-      expect.stringContaining(encodeURIComponent('/no_image.jpg')),
+      '/no_image.jpg',
     )
     expect(getByTestId('bookImg')).toHaveAttribute('alt', bookWithoutImage.title)
   })

--- a/src/components/bookTile.test.tsx
+++ b/src/components/bookTile.test.tsx
@@ -18,10 +18,7 @@ describe('book component', () => {
     const { getByText, getByTestId } = render(<BookTile book={bookWithoutImage} />)
 
     expect(getByText(bookWithoutImage.title)).toBeInTheDocument()
-    expect(getByTestId('bookImg')).toHaveAttribute(
-      'src',
-      '/no_image.jpg',
-    )
+    expect(getByTestId('bookImg')).toHaveAttribute('src', '/no_image.jpg')
     expect(getByTestId('bookImg')).toHaveAttribute('alt', bookWithoutImage.title)
   })
 

--- a/src/components/bookTile.tsx
+++ b/src/components/bookTile.tsx
@@ -28,6 +28,7 @@ const Tile: FC<BookProps> = ({ book }) => {
       <div className="h-[400px] overflow-hidden">
         <Image
           src={book.imageUrl ? book.imageUrl : '/no_image.jpg'}
+          unoptimized={!book.imageUrl}
           alt={book.title}
           width={300}
           height={400}


### PR DESCRIPTION
## 内容

E2Eテスト実行中に以下の警告が出ていた問題を修正します。

```
[WebServer] ⨯ The requested resource isn't a valid image for /no_image.jpg received null
```

### 原因

`imageUrl` が未設定の書籍を表示する際、フォールバックとして `/no_image.jpg` を使用しています。Next.js の画像最適化パイプラインが開発サーバー（`yarn dev`）でこのローカル画像を処理しようとした際に `null` を受け取り、警告を出力していました。

### 対応

`imageUrl` が無い場合（フォールバック時）のみ `unoptimized={true}` を設定し、Next.js の最適化パイプラインをスキップするようにしました。`imageUrl` がある場合（外部URL）は従来通り最適化されます。

### 変更ファイル

- `src/components/bookTile.tsx`
- `src/app/books/[id]/bookDetail.tsx`

https://claude.ai/code/session_01N7oBzSpmYUhDr2gKkg1vYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7oBzSpmYUhDr2gKkg1vYC)_