### PR TITLE
npmMinimalAgeGate を 3 日に設定してサプライチェーン攻撃対策を強化

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+# サプライチェーン攻撃対策: 公開から3日未満のバージョンは解決対象から除外する
+# renovate.json の minimumReleaseAge (3 days) と同じ期間に揃えている
+npmMinimalAgeGate: 3d

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,5 @@
-nodeLinker: node-modules
+nodeLinker: "node-modules"
 
 # サプライチェーン攻撃対策: 公開から3日未満のバージョンは解決対象から除外する
 # renovate.json の minimumReleaseAge (3 days) と同じ期間に揃えている
-npmMinimalAgeGate: 3d
+npmMinimalAgeGate: "3d"


### PR DESCRIPTION
## 内容

`.yarnrc.yml` に `npmMinimalAgeGate: 3d` を追加し、npm パッケージの最小公開期間を 3 日に設定しました。

これにより、公開から 3 日未満の新しいバージョンは依存関係の解決対象から除外され、サプライチェーン攻撃のリスクを低減します。この設定は `renovate.json` の `minimumReleaseAge` と同じ期間に統一されており、プロジェクト全体で一貫した安全性ポリシーが適用されます。

## 動作確認項目

- N/A（設定ファイルの変更のため、自動テストで検証されます）

## 関連するIssue

なし

https://claude.ai/code/session_01GSYM7aXQTnJoVhpYLPFdqB