### PR TITLE
検索エンジンのクローリングを禁止する robots.txt を追加

### DIFF
--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import robots from './robots'
+
+describe('robots', () => {
+  it('全てのクローラーに対して全パスのクロールを禁止する', () => {
+    expect(robots()).toEqual({
+      rules: {
+        userAgent: '*',
+        disallow: '/',
+      },
+    })
+  })
+})

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next'
+
+// 社内向けシステムのため、検索エンジンによるクローリングを全面的に禁止する
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: '/',
+    },
+  }
+}


### PR DESCRIPTION
## 内容

社内向けの図書館管理システムであるため、検索エンジンによるクロールを全面的に禁止する robots.txt を配信するようにしました。

これまでリポジトリに robots.txt は存在していませんでした（`public/` 配下にも `src/app/` 配下にもなし）。

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/app/robots.ts` | Next.js App Router の Metadata API による robots.txt の定義（新規） |
| `src/app/robots.test.ts` | 上記のユニットテスト（新規） |

```ts
export default function robots(): MetadataRoute.Robots {
  return {
    rules: { userAgent: '*', disallow: '/' },
  }
}
```

### 実装方針

`public/robots.txt` の静的ファイルではなく Metadata API を採用しました。

- App Router + `typedRoutes` 構成に沿う形にするため
- `MetadataRoute.Robots` の型で内容が担保されるため
- 将来 sitemap の追加やルールの出し分けが必要になった際に分岐を書けるため

なお `src/proxy.ts` の認証ミドルウェアは matcher で既に `robots.txt` を除外済みのため、middleware 側の変更は不要でした。除外されていない場合、未認証のクローラーが `/auth/signIn` にリダイレクトされて robots.txt 自体を読めなくなります。

## 動作確認項目

ローカルで以下をすべて実行し、成功を確認しています。

- [x] `yarn typeCheck` — 成功
- [x] `yarn lint:fix` — 102 ファイルチェック、修正なし
- [x] `yarn test` — 39 ファイル / 194 テスト成功
- [x] `yarn build` — 成功。ビルド出力で `/robots.txt` が `○ (Static)` として静的生成されることを確認

生成された成果物の中身も確認済みです。

```
User-Agent: *
Disallow: /
```

## レビュー希望日

特に急ぎではありません。ご都合のよいタイミングでお願いします。

## 関連するIssue

なし

---

### 補足・ご相談

robots.txt はクロールを抑止するものであり、**インデックス登録を防ぐことを保証するものではありません**。外部からリンクされた URL は、クロールされなくても検索結果に表示される可能性があります。

確実に排除したい場合は `src/app/layout.tsx` の metadata に `robots: { index: false, follow: false }`（`noindex` メタタグ）を併用するのが一般的です。今回は依頼の範囲を robots.txt の追加としたため含めていませんが、必要であればこの PR に追加します。

ただし本アプリは `proxy.ts` の認証ミドルウェアでほぼ全ページが保護されており、クローラーが到達できるのは実質 `/auth/signIn` 程度のため、もともと露出リスクは限定的です。

---
_Generated by [Claude Code](https://claude.ai/code/session_014XnuZcTbhaLShLq7GSLgHa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a robots policy that prevents search engine crawlers from accessing any site pages.

* **Tests**
  * Added automated coverage to verify the crawler access restrictions are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->