### PR TITLE
Renovateワークフローにmainブランチの依存関係ファイル更新トリガーを追加

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,17 @@ on:
     types: [edited]
   pull_request:
     types: [edited]
+  # デフォルトブランチ上でRenovateが管理する依存関係定義ファイルが更新されたときにも実行する
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - yarn.lock
+      - docker-compose.yml
+      - mise.toml
+      - .github/workflows/**
+      - renovate.json
 
 concurrency:
   group: renovate
@@ -29,6 +40,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (
         github.event_name == 'issues' &&
         github.event.issue.title == 'Dependency Dashboard' &&


### PR DESCRIPTION
## 内容

PR #630 のフォローアップです。

- mainブランチへのpushのうち、Renovateが管理する依存関係定義ファイル（`package.json`, `yarn.lock`, `docker-compose.yml`, `mise.toml`, `.github/workflows/**`, `renovate.json`）に変更があった場合にワークフローを実行する `push` トリガーを追加
  - Renovateが作成したPRのマージなど、デフォルトブランチ上の依存関係が更新されたタイミングで即座にRenovateを再実行できるようにする

## 動作確認項目

- [ ] mainブランチで対象ファイル（例: `package.json`）が更新された際にワークフローが起動することを確認

## レビュー希望日

特に指定なし

## 関連するIssue

なし（PR #619, #630 のフォローアップ）

https://claude.ai/code/session_01CkPx4N7f78SrkUpcJrjtAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkPx4N7f78SrkUpcJrjtAR)_