### PR TITLE
Renovate GitHub App認証の設定を更新

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -56,7 +56,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # Renovate公式ドキュメント（https://docs.renovatebot.com/security-and-permissions/）の
           # 権限マトリクスに合わせて、発行するトークンの権限をインストール権限全体ではなく必要最小限に絞る

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -56,7 +56,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # Renovate公式ドキュメント（https://docs.renovatebot.com/security-and-permissions/）の
           # 権限マトリクスに合わせて、発行するトークンの権限をインストール権限全体ではなく必要最小限に絞る


### PR DESCRIPTION
## 内容

GitHub Actions の `create-github-app-token` アクションの設定を更新しました。

**変更内容:**
- `app-id` パラメータを `client-id` に変更
- 値を `secrets.RENOVATE_APP_ID` から `vars.RENOVATE_APP_CLIENT_ID` に変更

この変更により、GitHub App認証がより新しい推奨方式に対応します。`client-id` は環境変数（vars）として管理され、より安全な認証フローを実現します。

## 動作確認項目

- [ ] Renovate ワークフローが正常に実行されることを確認
- [ ] GitHub App トークンが正しく生成されることを確認
- [ ] 既存の Renovate 機能（依存関係の更新検出、PR作成など）が動作することを確認

## 関連するIssue

なし

https://claude.ai/code/session_017mR9UxD9xrGBX94Qt6mZQt