### PR TITLE
不要になった@hono/node-serverのresolutionを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,5 @@
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.10",
     "vitest-mock-extended": "^5.1.0"
-  },
-  "resolutions": {
-    "@hono/node-server": "2.0.12"
   }
 }


### PR DESCRIPTION
## 内容

`package.json` の `resolutions` フィールドから `@hono/node-server` の指定を削除しました。

この resolution は `@hono/node-server` の脆弱性対応(2.0.4 → 2.0.10 → 2.0.12)のために追加されたものですが、現在の依存関係ツリーには `hono` / `@hono/node-server` を要求するパッケージが存在せず、`yarn.lock` 上も何の解決にも寄与していない死んだ設定になっていました。

## 動作確認項目

- [x] `yarn install` で再生成しても `yarn.lock` に差分が発生しないことを確認(このresolutionが実際には何も解決していなかったことの裏付け)
- [x] `yarn typeCheck` が成功することを確認
- [x] `yarn lint:fix` で新たな指摘がないことを確認
- [x] `yarn test`(39ファイル / 194テスト)が全て成功することを確認

## レビュー希望日

## 関連するIssue

なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKcoRmXhgCejf7qXabBJng)_